### PR TITLE
Add cors_allowed_origins parameter for frontend

### DIFF
--- a/sioserver.py
+++ b/sioserver.py
@@ -10,7 +10,7 @@ SENSORS = set()
 CLIENTS = set()
 SUBSCRIBERS = set()
 
-sio = socketio.AsyncServer()
+sio = socketio.AsyncServer(cors_allowed_origins='http://localhost:8080')
 app = web.Application()
 sio.attach(app)
 


### PR DESCRIPTION
This PR allows the mock data to be sent from simoc-sam to simoc-web. It resolves the following issue.

Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://localhost:8081/socket.io/?EIO=4&transport=polling&t=NslouJ3. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing)