### PR TITLE
Add logic into Dockerfile to install ARMhf dependencies only if needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,11 @@ RUN apt-get update && \
     python3-pip \
     python3-setuptools \
     curl \
-    wget
-
-# Additional dependencies, conditionally installed, for ARMhf (especially Raspberry Pi)
-Run if [ $(dpkg --print-architecture) = 'armhf' ]; then \
-        echo "Installing additonal dependencies for ARMhf Architecture"; \
+    wget && \
+    if [ $(dpkg --print-architecture) = 'armhf' ]; then \
         apt-get install -y --no-install-recommends --upgrade \
         gcc-arm-linux-gnueabihf \
         python3-dev; \
-    else \
-        echo "Architecture is not ARMhf, so additional dependencies not needed."; \
     fi
 
 # if we need more modules use a requirements.txt file


### PR DESCRIPTION
This pull request is to replace the Dockerfile with one that has the logic needed to add the Raspberry Pi dependencies automatically. I have tested this to successfully install the correct image on both my Raspberry Pi 4 and also my AMD64 Linux laptop.