### PR TITLE
Avoid leaving Docker containers around.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker build . -t sioserver
 
 You can then start the container with:
 ```sh
-docker run -it -p 8080:8080 sioserver
+docker run --rm -it -p 8080:8080 sioserver
 ```
 
 Once the container is running you can access the test client at
@@ -42,7 +42,7 @@ changes you do to these files won't be reflected unless you rebuild the image.
 
 To avoid that, you can override the content of the `/sioserver` by using:
 ```sh
-docker run -it -p 8081:8080 -v `pwd`:/sioserver sioserver
+docker run --rm -it -p 8081:8080 -v `pwd`:/sioserver sioserver
 ```
 After this you can edit the client and just reload the page to see the changes.
 If you modify the server you will have to restart it.
@@ -88,7 +88,7 @@ Start everything at once using `tmux`:
 Start server/sensor(s)/client(s) separately:
 ```sh
 # start the Docker container and the socketio server
-docker run -it -p 8081:8080 -v `pwd`:/sioserver sioserver
+docker run --rm -it -p 8081:8080 -v `pwd`:/sioserver sioserver
 # start the fake sensor (on a new terminal tab on the host machine)
 python3 mocksensor.py -v --port 8081
 # start the client (on a new terminal tab on the host machine)

--- a/tmux.sh
+++ b/tmux.sh
@@ -5,7 +5,7 @@ SIOPORT=8081
 # create a new session and set the num of cols/lines
 tmux new-session -s $SNAME -d -x "$(tput cols)" -y "$(tput lines)"
 # start the server in the first pane
-tmux send-keys -t $SNAME "docker run -it -p $SIOPORT:8080 -v `pwd`:/sioserver sioserver" Enter
+tmux send-keys -t $SNAME "docker run --rm -it -p $SIOPORT:8080 -v `pwd`:/sioserver sioserver" Enter
 # create 4 more panes and run the sensors and clients
 tmux split-window -h -p 65
 tmux send-keys -t $SNAME 'sleep 5' Enter "python3 scd30.py -v --port $SIOPORT" Enter


### PR DESCRIPTION
I realized that the `docker run` command we were using in `tmux.sh` and recommending in the doc created a new container every time without removing them afterwards.  I now add `--rm` so that the containers are automatically removed. 