### PR TITLE
Add config file support for sensors.

### DIFF
--- a/basesensor.py
+++ b/basesensor.py
@@ -23,8 +23,9 @@ class BaseSensor(ABC):
         # override this with a regular class attr in the subclasses
         raise NotImplementedError()
 
-    def __init__(self, *, name=None, verbose=False):
+    def __init__(self, *, name=None, description=None, verbose=False):
         self.sensor_name = name
+        self.sensor_desc = description
         self.verbose = verbose
         # the total number of values read through iter_readings
         self.reading_num = 0
@@ -46,6 +47,7 @@ class BaseSensor(ABC):
         return {
             'sensor_type': self.sensor_type,
             'sensor_name': self.sensor_name,
+            'sensor_desc': self.sensor_desc,
             'reading_info': self.reading_info,
         }
 

--- a/config.cfg.tmpl
+++ b/config.cfg.tmpl
@@ -1,0 +1,24 @@
+# Copy this template file to config.cfg and add/edit the fields.
+# The host section contains info about the host type (e.g. Raspberry,
+# PC) and its location.
+# All the section with a name starting with 'sensor' are used to
+# describe sensors.  The right section is determined by matching
+# the sensor type, which means that only one sensor per type can
+# be used on a given host.
+# E.g. if you launch an SCD-30 it will pick the name and description
+# set in a [sensor*] section that contains type=SCD-30.
+
+[host]
+location=Greenhouse
+type=Raspberry
+
+
+[Sensor0]
+type=SCD-30
+name=SCD-30-Greenhouse
+description=CO2/temperature/humidity sensor placed in the greenhouse
+
+[Sensor1]
+type=Mock
+name=Mock-Sensor-Greenhouse
+description=A mock sensor used for testing

--- a/mocksensor.py
+++ b/mocksensor.py
@@ -13,8 +13,8 @@ class MockSensor(BaseSensor):
     }
     """A mock server that generates random CO2/temperature/humidity data."""
     def __init__(self, *, base_co2=500, base_temp=20, base_hum=50,
-                 name='MockSensor', verbose=False):
-        super().__init__(name=name, verbose=verbose)
+                 name='MockSensor', description=None, verbose=False):
+        super().__init__(name=name, description=description, verbose=verbose)
         self.co2_ppm = base_co2
         self.temp = base_temp
         self.rel_hum = base_hum

--- a/scd30.py
+++ b/scd30.py
@@ -28,9 +28,9 @@ class SCD30(BaseSensor):
         'rel_hum': dict(label='Relative Humidity', unit='%'),
     }
     """Represent a SCD-30 sensors connected through a MCP2221."""
-    def __init__(self, *, name='SCD-30', verbose=False):
+    def __init__(self, *, name='SCD-30', description=None, verbose=False):
         """Initialize the sensor."""
-        super().__init__(name=name, verbose=verbose)
+        super().__init__(name=name, description=description, verbose=verbose)
         i2c = busio.I2C(board.SCL, board.SDA, frequency=50000)
         self.scd = adafruit_scd30.SCD30(i2c)
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import configparser
 
 from datetime import datetime
 
@@ -24,6 +25,15 @@ def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
         result.append(f'{label}: {v}{unit}')
     return f'{sensor_name}|{timestamp}|{n:<3}  {"; ".join(result)}'
 
+
+def get_sensor_info_from_cfg(sensor_type, cfg_file='config.cfg'):
+    config = configparser.ConfigParser()
+    config.read(cfg_file)
+    for name, section in config.items():
+        if not name.lower().startswith('sensor'):
+            continue  # not a section about sensors
+        if section['type'].lower() == sensor_type.lower():
+            return dict(section)
 
 def parse_args(*, read_delay=1, port=8081):
     parser = argparse.ArgumentParser()
@@ -52,6 +62,12 @@ def parse_args(*, read_delay=1, port=8081):
 
 def start_sensor(sensor_cls, *pargs, **kwargs):
     args = parse_args()
+    sensor_info = get_sensor_info_from_cfg(sensor_cls.sensor_type)
+    # get the name/desc from the config unless the user passed them as kwargs
+    # TODO: add cmd line options for name/desc that override the cfg too
+    for attr in ['name', 'description']:
+        if attr not in kwargs and sensor_info and attr in sensor_info:
+            kwargs[attr] = sensor_info[attr]
     with sensor_cls(verbose=args.verbose_sensor, *pargs, **kwargs) as sensor:
         if args.no_sio:
             for reading in sensor.iter_readings(delay=args.delay):


### PR DESCRIPTION
This PR adds basic support for the config parser file we discussed.
It is limited to a sensor type per host, i.e. you can have an SCD and a BNE, but you can't have two SCDs.  This is because the code currently uses the sensor type to find the right section.

A few thing that we should determine:
* The host section contains info about the host type and location, but they are currently unused.  The location could be added as a sensor attribute and set to all sensors automatically, but all drivers must be updated to support it.
* I added a `description` that is passed with the sensor info, but currently unused.  If we don't need it we could remove it.  If we keep it, all the sensor drivers should be updated to support it.
* Instead of having specific attributes for name/description/location/etc., it might be better to just save them all in a `sensor_info` dict.  This will also make it easier to add new attributes in the future.
* Since we are limited to one sensor per type, we could use the sensor type as section name (e.g. `[SCD-30]`).
* If we want to support multiple sensors of the same type, we have to figure out a way to distinguish them.
* Some error checking should be added in case the cfg is missing.
* We should add options to pass the name/desc from the command line.
* Currently the repo contains both the client and the server, and in theory the server should get a cfg file too that contains info about the number of humans, possibly the crew number/name, info about their mission, etc..  In theory we could still use the same `config.cfg` for that too, or we could split them into `server.cfg` and `client.cfg` (even though the name `client` is a bit confusing, since the frontend is a client too).

This is an example of sensor info received by the server:
```py
{'sensor_type': 'Mock',
 'sensor_name': 'Mock-Sensor-Greenhouse',
 'sensor_desc': 'A mock sensor used for testing',
 'reading_info': {
    'co2': {'label': 'CO2', 'unit': 'ppm'},
    'temp': {'label': 'Temperature', 'unit': '°C'}, 
    'rel_hum': {'label': 'Relative Humidity', 'unit': '%'}
 }}
```