### PR TITLE
switch default port to 8081 in all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ docker build . -t sioserver
 
 You can then start the container with:
 ```sh
-docker run --rm -it -p 8080:8080 sioserver
+docker run --rm -it -p 8081:8080 sioserver
 ```
 
 Once the container is running you can access the test client at
-http://0.0.0.0:8080/
+http://0.0.0.0:8081/
 
 
-If you want to use a different port, use e.g. `-p 8081:8080` and
-open http://0.0.0.0:8081/ instead.
+If you want to use a different port, use e.g. `-p 8082:8080` and
+open http://0.0.0.0:8082/ instead.
 
 When the image is built, both the server and the client (and all other files)
 are copied in the `/sioserver` directory of the container.  This means that
@@ -84,7 +84,7 @@ The repository includes two socketio clients:
 * A JS one in `index.html`
 * A standalone Python one (`sioclient.py`)
 
-To access the JS client simply open http://0.0.0.0:8080/ in the browser,
+To access the JS client simply open http://0.0.0.0:8081/ in the browser,
 with the server running inside or outside the Docker container.
 
 To run the Python client run `python3 sioclient.py <port>`.  You can run
@@ -93,7 +93,7 @@ the server inside the container and the Python client inside or outside.
 Regardless of the setup you choose, you must ensure that you are using the
 correct port either in the URL (for the JS client) or as a command line
 argument (for the Python client).  By default the server will serve on
-port `8080`, unless you specified a different port with e.g. `-p 8081:8080`
+port `8081`, unless you specified a different port with e.g. `-p 8082:8080`
 while running the server inside the container.
 
 

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -26,7 +26,7 @@ def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
     return f'{sensor_name}|{timestamp}|{n:<3}  {"; ".join(result)}'
 
 
-def parse_args(*, read_delay=1, port=8080):
+def parse_args(*, read_delay=1, port=8081):
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--read-delay', default=read_delay,
                         dest='delay', metavar='DELAY', type=int,

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -158,4 +158,4 @@ async def init_app(app):
 
 if __name__ == '__main__':
     app = create_app()
-    web.run_app(init_app(app))
+    web.run_app(init_app(app), port=8081)

--- a/tests/test_basesensor.py
+++ b/tests/test_basesensor.py
@@ -88,8 +88,8 @@ async def test_siowrapper(sensor):
     # mock the socketio.AsyncClient instance
     siowrapper.sio = sio_ac = AsyncMock(spec=siowrapper.sio)
     # start the client and check it connects to the server
-    await siowrapper.start(8080)
-    sio_ac.connect.assert_awaited_with('http://localhost:8080')
+    await siowrapper.start(8081)
+    sio_ac.connect.assert_awaited_with('http://localhost:8081')
     # check that sensor registers itself on connect
     await siowrapper.connect()
     sensor_info = {'sensor_type': 'TestSensor', 'sensor_name': None,

--- a/tmux.sh
+++ b/tmux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # set vars
 SNAME=SAM
-SIOPORT=8080
+SIOPORT=8081
 # activate venv
 echo -n 'Activating venv...   '
 . venv/bin/activate


### PR DESCRIPTION
As discussed, SIMOC-SAM should use port 8081 by default so that it works with SIMOC-web, which always uses port 8080.

This essentially does 3 things:
1) the `aio` server is launched on port `8081` by default (in sioserver.py).
2) the Docker commands use port `8081` by default. Before it was inconsistent.
3) the `basesensor` listens/broadcasts on port `8081` by default.

All 3 main commands from `simoc-sam.py` (run-server, run-tmux, test) are working.

One issue/question: for 1) above, there's no way to change the port besides changing the hard-coding on line 161. Do we want add a command-line arg for this?