### PR TITLE
add random id to basesensor if not provided

### DIFF
--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -1,10 +1,16 @@
 import time
+import random
 import asyncio
 
 from datetime import datetime
 from abc import ABC, abstractmethod
 
 import socketio
+
+
+def random_id(length=6):
+    """Return a random hexadecimal string of specified length"""
+    return ''.join(random.choice('0123456789ABCDEF') for i in range(length))
 
 
 class BaseSensor(ABC):
@@ -26,7 +32,7 @@ class BaseSensor(ABC):
     def __init__(self, *, name=None, id=None, description=None,
                  verbose=False):
         self.sensor_name = name
-        self.sensor_id = id
+        self.sensor_id = id or random_id()
         self.sensor_desc = description
         self.verbose = verbose
         # the total number of values read through iter_readings

--- a/tests/test_basesensor.py
+++ b/tests/test_basesensor.py
@@ -93,7 +93,7 @@ async def test_siowrapper(sensor):
     # check that sensor registers itself on connect
     await siowrapper.connect()
     sensor_info = {'sensor_type': 'TestSensor', 'sensor_name': None,
-                   'sensor_id': None, 'sensor_desc': None,
+                   'sensor_id': sensor.sensor_id, 'sensor_desc': None,
                    'reading_info': INFO}
     sio_ac.emit.assert_awaited_with('register-sensor', sensor_info)
     # request 2 readings and check that at least a reading has been sent


### PR DESCRIPTION
ID will be required for coordinating server actions. Ideally it will be implemented by the Sensor classes (device serial number for Vernier, USB port for others) but this will at least cover MockSensor.