### PR TITLE
Fix Vernier sensors finalization.

### DIFF
--- a/src/simoc_sam/sensors/vernier.py
+++ b/src/simoc_sam/sensors/vernier.py
@@ -23,7 +23,10 @@ def init_sensors():
             print(f'Found unrecognized device: {name}')
             break
     print(sensor_classes)
-    start_sensors(sensor_classes)
+    try:
+        start_sensors(sensor_classes)
+    finally:
+        gd.quit()
 
 
 if __name__ == '__main__':

--- a/src/simoc_sam/sensors/vernierCO2.py
+++ b/src/simoc_sam/sensors/vernierCO2.py
@@ -20,6 +20,9 @@ class VernierCO2(BaseSensor):
         self.device.select_sensors([1, 2, 3])
         self.device.start()
 
+    def __exit__(self, type, value, traceback):
+        self.device.close()
+
     def read_sensor_data(self):
         """Return sensor data (CO2, temperature, humidity) as a dict."""
         measurements = self.device.read()

--- a/src/simoc_sam/sensors/vernierO2.py
+++ b/src/simoc_sam/sensors/vernierO2.py
@@ -19,6 +19,9 @@ class VernierO2(BaseSensor):
         self.device.select_sensors([1, 2, 3])  # o2, temp-corrected o2, temp
         self.device.start()
 
+    def __exit__(self, type, value, traceback):
+        self.device.close()
+
     def read_sensor_data(self):
         """Return sensor data (O2, temperature) as a dict."""
         measurements = self.device.read()


### PR DESCRIPTION
This PR fixes the Vernier sensors finalization by calling `device.close()` on `exit`.