### PR TITLE
Fix CORS `allowed_origins` port.

### DIFF
--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -22,7 +22,11 @@ CLIENTS = set()
 SUBSCRIBERS = set()
 
 
-allowed_origins = [f'http://{SIO_HOST}:{SIO_PORT}']
+# The web client will include the Origin header with their host:port
+# (e.g. localhost:8080), so we should accept that explicitly.
+# The sensors and the Python client don't send the Origin header,
+# and they work without being allowed explicitly.
+allowed_origins = [f'http://{SIO_HOST}:8080']
 sio = socketio.AsyncServer(cors_allowed_origins=allowed_origins,
                            async_mode='aiohttp')
 


### PR DESCRIPTION
From https://python-socketio.readthedocs.io/en/latest/server.html#cross-origin-controls:
> * If an incoming HTTP or WebSocket request includes the Origin header, this header must match the scheme and host of the connection URL. In case of a mismatch, a 400 status code response is returned and the connection is rejected.
> * No restrictions are imposed on incoming requests that do not include the Origin header.

When using the dashboard -- served on `localhost:8080` -- the browser will include the `Origin` header and will specify `localhost:8080`, so this value must be explicitly accepted by the sioserver.  Currently the sioserver is serving on `localhost:8081`, so even though the host is the same, the port is different and using `8081` results in a dashboard error.

The problem does not subsist for other Python clients/sensors, since the websocket connection is not initiated by a browser and doesn't send an `Origin` header.