### PR TITLE
Use correct var names when reading the config.

### DIFF
--- a/config.cfg.tmpl
+++ b/config.cfg.tmpl
@@ -16,9 +16,9 @@ type=Raspberry
 [Sensor0]
 type=SCD-30
 name=SCD-30-Greenhouse
-description=CO2/temperature/humidity sensor placed in the greenhouse
+desc=CO2/temperature/humidity sensor placed in the greenhouse
 
 [Sensor1]
 type=Mock
 name=Mock-Sensor-Greenhouse
-description=A mock sensor used for testing
+desc=A mock sensor used for testing

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -84,9 +84,9 @@ async def register_sensor(sid, sensor_info):
     if sensor_id:
         sensor_meta = get_sensor_info_from_cfg(sensor_id)
         if sensor_meta:
-            for attr in ['name', 'description']:
-                if attr in sensor_meta and not sensor_info[attr]:
-                    sensor_info[attr] = sensor_meta[attr]
+            for attr in ['name', 'desc']:
+                if attr in sensor_meta and not sensor_info[f'sensor_{attr}']:
+                    sensor_info[f'sensor_{attr}'] = sensor_meta[attr]
     print('Sensor info:', sensor_info)
     SENSOR_INFO[sid] = sensor_info
     await emit_to_subscribers('sensor-info', SENSOR_INFO)


### PR DESCRIPTION
This PR fixes two issues that prevented the server from running properly:
* `sioserver.py` is currently looking for `name` and `description` in the config, even though we settled on `name` and `desc`
* the `sensor_info`s use `sensor_name` and `sensor_desc`, so when comparing with those, the `sensor_` prefix is added

The logic also seems backward, since the `sensor_info` values take precedence over the config file, whereas it should be the opposite.  I'll fix this in a separate PR after some additional testing.