### PR TITLE
Add vernier-WTHR sensor driver.

### DIFF
--- a/src/simoc_sam/sensors/vernier.py
+++ b/src/simoc_sam/sensors/vernier.py
@@ -2,6 +2,7 @@ from godirect import GoDirect
 
 from .vernierCO2 import VernierCO2
 from .vernierO2 import VernierO2
+from .vernierWTHR import VernierWTHR
 from .vernier_utils import start_sensors
 
 def init_sensors():
@@ -17,8 +18,11 @@ def init_sensors():
             print(f'Found CO2 sensor {serial_number}; starting device...')
             sensor_classes.append((VernierCO2, device, dict(id=serial_number)))
         elif name.startswith('GDX-O2'):
-            print(f'Found O2 sensor {serial_number}; starting deivce...')
+            print(f'Found O2 sensor {serial_number}; starting device...')
             sensor_classes.append((VernierO2, device, dict(id=serial_number)))
+        elif name.startswith('GDX-WTHR'):
+            print(f'Found Weather sensor {serial_number}; starting device...')
+            sensor_classes.append((VernierWTHR, device, dict(id=serial_number)))
         else:
             print(f'Found unrecognized device: {name}')
             break

--- a/src/simoc_sam/sensors/vernierWTHR.py
+++ b/src/simoc_sam/sensors/vernierWTHR.py
@@ -1,0 +1,78 @@
+import sys
+
+from .basesensor import BaseSensor
+from .vernier_utils import gdx_lite
+
+class VernierWTHR(BaseSensor):
+    sensor_type = 'Vernier-WTHR'
+    reading_info = {
+        'wind_speed': dict(label='Wind Speed', unit='m/s'),
+        'wind_direction': dict(label='Wind Direction', unit='°'),
+        'wind_chill': dict(label='Wind Chill', unit='°C'),
+        'temperature': dict(label='Temperature', unit='°C'),
+        'heat_index': dict(label='Heat Index', unit='°C'),
+        'dew_point': dict(label='Dew Point', unit='°C'),
+        'relative_humidity': dict(label='Relative Humidity', unit='%'),
+        'absolute_humidity': dict(label='Absolute Humidity', unit='g/m^3'),
+        'station_pressure': dict(label='Station Pressure', unit='mbar'),
+        'barometric_pressure': dict(label='Barometric Pressure', unit='mbar'),
+        'altitude': dict(label='Altitude', unit='m'),
+    }
+
+    def __init__(self, *, device=None, name='Vernier Weather', **kwargs):
+        """Initialize the sensor."""
+        if device is None:
+            raise ValueError('Missing device. Try running with vernier.py')
+        super().__init__(name=name, **kwargs)
+        self.device = gdx_lite(device)
+        self.device.select_sensors([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+        self.device.start()
+
+    def __exit__(self, type, value, traceback):
+        self.device.close()
+
+    def read_sensor_data(self):
+        """Return all sensor data as a dict."""
+        measurements = self.device.read()
+
+        wind_speed = measurements[0]  # m/s
+        wind_direction = measurements[1]  # °
+        wind_chill = measurements[2]  # °C
+        temperature = measurements[3]  # °C
+        heat_index = measurements[4]  # °C
+        dew_point = measurements[5]  # °C
+        relative_humidity = measurements[6]  # %
+        absolute_humidity = measurements[7]  # g/m^3
+        station_pressure = measurements[8]  # mbar
+        barometric_pressure = measurements[9]  # mbar
+        altitude = measurements[10]  # m
+
+        if self.verbose:
+            print(f'Wind Speed: {wind_speed:2.1f}m/s; '
+                  f'Wind Direction: {wind_direction:2.1f}°; '
+                  f'Wind Chill: {wind_chill:2.1f}°C; '
+                  f'Temperature: {temperature:2.1f}°C; '
+                  f'Heat Index: {heat_index:2.1f}°C; '
+                  f'Dew Point: {dew_point:2.1f}°C; '
+                  f'Relative Humidity: {relative_humidity:2.1f}%; '
+                  f'Absolute Humidity: {absolute_humidity:2.1f}g/m^3; '
+                  f'Station Pressure: {station_pressure:2.1f}mbar; '
+                  f'Barometric Pressure: {barometric_pressure:2.1f}mbar; '
+                  f'Altitude: {altitude:2.1f}m; [{self.sensor_type}]')
+        return dict(
+            wind_speed=wind_speed,
+            wind_direction=wind_direction,
+            wind_chill=wind_chill,
+            temperature=temperature,
+            heat_index=heat_index,
+            dew_point=dew_point,
+            relative_humidity=relative_humidity,
+            absolute_humidity=absolute_humidity,
+            station_pressure=station_pressure,
+            barometric_pressure=barometric_pressure,
+            altitude=altitude,
+        )
+
+if __name__ == '__main__':
+    sys.exit('Vernier sensors cannot be launched independently.')
+    # start_sensor(VernierWTHR)

--- a/src/simoc_sam/sensors/vernierWTHR.py
+++ b/src/simoc_sam/sensors/vernierWTHR.py
@@ -9,13 +9,13 @@ class VernierWTHR(BaseSensor):
         'wind_speed': dict(label='Wind Speed', unit='m/s'),
         'wind_direction': dict(label='Wind Direction', unit='°'),
         'wind_chill': dict(label='Wind Chill', unit='°C'),
-        'temperature': dict(label='Temperature', unit='°C'),
+        'temp': dict(label='Temperature', unit='°C'),
         'heat_index': dict(label='Heat Index', unit='°C'),
         'dew_point': dict(label='Dew Point', unit='°C'),
-        'relative_humidity': dict(label='Relative Humidity', unit='%'),
+        'rel_hum': dict(label='Relative Humidity', unit='%'),
         'absolute_humidity': dict(label='Absolute Humidity', unit='g/m^3'),
         'station_pressure': dict(label='Station Pressure', unit='mbar'),
-        'barometric_pressure': dict(label='Barometric Pressure', unit='mbar'),
+        'pressure': dict(label='Barometric Pressure', unit='mbar'),
         'altitude': dict(label='Altitude', unit='m'),
     }
 
@@ -38,38 +38,38 @@ class VernierWTHR(BaseSensor):
         wind_speed = measurements[0]  # m/s
         wind_direction = measurements[1]  # °
         wind_chill = measurements[2]  # °C
-        temperature = measurements[3]  # °C
+        temp = measurements[3]  # °C
         heat_index = measurements[4]  # °C
         dew_point = measurements[5]  # °C
-        relative_humidity = measurements[6]  # %
+        rel_hum = measurements[6]  # %
         absolute_humidity = measurements[7]  # g/m^3
         station_pressure = measurements[8]  # mbar
-        barometric_pressure = measurements[9]  # mbar
+        pressure = measurements[9]  # mbar
         altitude = measurements[10]  # m
 
         if self.verbose:
             print(f'Wind Speed: {wind_speed:2.1f}m/s; '
                   f'Wind Direction: {wind_direction:2.1f}°; '
                   f'Wind Chill: {wind_chill:2.1f}°C; '
-                  f'Temperature: {temperature:2.1f}°C; '
+                  f'Temperature: {temp:2.1f}°C; '
                   f'Heat Index: {heat_index:2.1f}°C; '
                   f'Dew Point: {dew_point:2.1f}°C; '
-                  f'Relative Humidity: {relative_humidity:2.1f}%; '
+                  f'Relative Humidity: {rel_hum:2.1f}%; '
                   f'Absolute Humidity: {absolute_humidity:2.1f}g/m^3; '
                   f'Station Pressure: {station_pressure:2.1f}mbar; '
-                  f'Barometric Pressure: {barometric_pressure:2.1f}mbar; '
+                  f'Barometric Pressure: {pressure:2.1f}mbar; '
                   f'Altitude: {altitude:2.1f}m; [{self.sensor_type}]')
         return dict(
             wind_speed=wind_speed,
             wind_direction=wind_direction,
             wind_chill=wind_chill,
-            temperature=temperature,
+            temp=temp,
             heat_index=heat_index,
             dew_point=dew_point,
-            relative_humidity=relative_humidity,
+            rel_hum=rel_hum,
             absolute_humidity=absolute_humidity,
             station_pressure=station_pressure,
-            barometric_pressure=barometric_pressure,
+            pressure=pressure,
             altitude=altitude,
         )
 


### PR DESCRIPTION
This PR adds support for the [Vernier Weather System](https://www.vernier.com/product/go-direct-weather-system/) sensor.

The code is mostly copy-pasted from the other two Vernier drivers.  At some point we should refactor it to remove duplication and possibly write a universal driver that will support all Vernier sensors.