### PR TITLE
Attach to existing tmux session if it is already running.

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -13,6 +13,7 @@ VENV_DIR = SIMOC_SAM_DIR / 'venv'
 VENV_PY = str(VENV_DIR / 'bin' / 'python3')
 DEPS = 'requirements.txt'
 DEV_DEPS = 'dev-requirements.txt'
+TMUX_SNAME = 'SAM'  # tmux session name
 
 COMMANDS = {}
 
@@ -81,8 +82,11 @@ def run_server():
 @cmd
 @needs_venv
 def run_tmux():
-    """Run the tmux script."""
-    run(['./tmux.sh'])
+    """Run the tmux script (or attach to an existing session)."""
+    if run(['tmux', 'has-session', '-t', TMUX_SNAME]):
+        run(['tmux', 'attach-session', '-t', TMUX_SNAME])  # attach to sessions
+    else:
+        run(['./tmux.sh', TMUX_SNAME])  # start new sessions
 
 
 VERNIER_USB_RULES = """\

--- a/tmux.sh
+++ b/tmux.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # set vars
-SNAME=SAM
+SNAME=${1:-SAM}  # use provided session name or SAM as default
 SIOSERVER_ADDR=localhost:8081
 # activate venv
 echo -n 'Activating venv...   '


### PR DESCRIPTION
This PR updates the `simoc-sam.py run-tmux` command to check if a session is already running and attach to it if it already is.  If no session is running it will start a new one as usual.