### PR TITLE
Make `emit_readings()` more robust.

### DIFF
--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -113,7 +113,9 @@ async def register_client(sid):
 
 async def emit_to_subscribers(*args, **kwargs):
     # TODO: replace with a namespace
-    for client_id in SUBSCRIBERS:
+    # Iterate on a copy to avoid size changes
+    # caused by other threads adding/removing subs
+    for client_id in SUBSCRIBERS.copy():
         await sio.emit(*args, to=client_id, **kwargs)
 
 @sio.on('sensor-batch')

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -1,3 +1,4 @@
+import traceback
 import configparser
 
 from datetime import datetime
@@ -157,11 +158,16 @@ async def emit_readings():
             print(f'Broadcasting reading to {len(SUBSCRIBERS)} clients')
             timestamp = get_timestamp()
             sensors_readings = {sid: readings[-1]
-                                for sid, readings in SENSOR_READINGS.items()}
+                                for sid, readings in SENSOR_READINGS.items()
+                                if readings}
             bundle = dict(n=n, timestamp=timestamp, readings=sensors_readings)
-            # the frontend expects a list of bundles
-            await emit_to_subscribers('step-batch', [bundle])
-            n += 1
+            try:
+                # the frontend expects a list of bundles
+                await emit_to_subscribers('step-batch', [bundle])
+                n += 1
+            except Exception as e:
+                print('!!! Failed to emit step-batch:')
+                traceback.print_exc()
         await sio.sleep(1)
 
 


### PR DESCRIPTION
This should fix a somewhat rare issue that I've encountered:
https://github.com/overthesun/simoc-sam/blob/65156f94fa91bcf9ec63ba2d628beda54bd8789e/src/simoc_sam/sioserver.py#L181-L184
This piece of code executes `emit_readings` when the server starts, and `emit_readings` loops forever in a background task, sending readings to the clients:
https://github.com/overthesun/simoc-sam/blob/65156f94fa91bcf9ec63ba2d628beda54bd8789e/src/simoc_sam/sioserver.py#L150-L165
This in turn calls `emit_to_subscribers`, that sends the readings to each subscriber one by one:
https://github.com/overthesun/simoc-sam/blob/65156f94fa91bcf9ec63ba2d628beda54bd8789e/src/simoc_sam/sioserver.py#L113-L116

My understanding is that this background task is executed in a separate thread, but it's not thread safe.  If a new subscriber is added or removed while `emit_to_subscribers` is executing its loop, the code will fail because the `SUBSCRIBERS` set changed size during iteration.

It seems that sometimes, the frontend loses the connection.  I think this might happen when the CPU usage is so high that the dashboard is too slow to reply and something timeouts.  This was observed on the macmini (which is slow), and locally, by reducing the delay at which the sioserver sent readings to the client to 0.001s (instead of 1s at the end of `emit_readings`).

If this happens, the `try`/`except` will catch and ignore the error.  I also added an additional check (`if readings`) so that `emit_readings` doesn't try to read values from a sensor that hasn't produced any value yet.