### PR TITLE
Improve tmux layout and message logging.

### DIFF
--- a/src/simoc_sam/sioclient.py
+++ b/src/simoc_sam/sioclient.py
@@ -49,7 +49,7 @@ async def sensor_info(data):
 @sio.on('step-batch')
 async def step_batch(batch):
     """Handle batches of step data received by the server."""
-    print(f'Received a batch of {len(batch)} bundles from the server:')
+    #print(f'Received a batch of {len(batch)} bundles from the server:')
     to_csv(batch)
     for bundle in batch:
         for sensor, reading in bundle['readings'].items():
@@ -101,7 +101,7 @@ def to_csv(batch):
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames
             if not set(FIELDNAMES).issubset(fieldnames):
-                print('updating header')
+                print('Updating CSV header...')
                 with open('temp_output.csv', 'w') as f:
                     fieldnames += [f for f in FIELDNAMES if f not in fieldnames]
                     writer = csv.DictWriter(f, fieldnames=fieldnames)

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -156,8 +156,7 @@ async def emit_readings():
     while True:
         if SENSORS and SUBSCRIBERS:
             # TODO: set up a room for the clients and broadcast to the room
-            # TODO: improve ctrl+c handling
-            #print(f'Broadcasting reading to {len(SUBSCRIBERS)} clients')
+            # TODO: improve ctrl+c handling (see graceful shutdown)
             timestamp = get_timestamp()
             sensors_readings = {sid: readings[-1]
                                 for sid, readings in SENSOR_READINGS.items()

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -124,8 +124,8 @@ async def sensor_batch(sid, batch):
     #print(f'Received a batch of {len(batch)} readings from sensor {sid}:')
     SENSOR_READINGS[sid].extend(batch)
     sensor_info = SENSOR_INFO[sid]
-    for reading in batch:
-        print(utils.format_reading(reading, sensor_info=sensor_info))
+    #for reading in batch:
+        #print(utils.format_reading(reading, sensor_info=sensor_info))
 
 @sio.on('sensor-reading')
 async def sensor_reading(sid, reading):
@@ -133,7 +133,7 @@ async def sensor_reading(sid, reading):
     #print(f'Received a reading from sensor {sid}:')
     SENSOR_READINGS[sid].append(reading)
     sensor_info = SENSOR_INFO[sid]
-    print(utils.format_reading(reading, sensor_info=sensor_info))
+    #print(utils.format_reading(reading, sensor_info=sensor_info))
 
 @sio.on('refresh-sensors')
 async def refresh_sensors(sid, sensor_manager_id=None):
@@ -157,7 +157,7 @@ async def emit_readings():
         if SENSORS and SUBSCRIBERS:
             # TODO: set up a room for the clients and broadcast to the room
             # TODO: improve ctrl+c handling
-            print(f'Broadcasting reading to {len(SUBSCRIBERS)} clients')
+            #print(f'Broadcasting reading to {len(SUBSCRIBERS)} clients')
             timestamp = get_timestamp()
             sensors_readings = {sid: readings[-1]
                                 for sid, readings in SENSOR_READINGS.items()
@@ -167,6 +167,10 @@ async def emit_readings():
                 # the frontend expects a list of bundles
                 await emit_to_subscribers('step-batch', [bundle])
                 n += 1
+                if n%60 == 0:
+                    print(f'{len(SENSORS)} sensor(s); '
+                          f'{len(SUBSCRIBERS)} subscriber(s); '
+                          f'{n} readings broadcasted')
             except Exception as e:
                 print('!!! Failed to emit step-batch:')
                 traceback.print_exc()

--- a/tmux.sh
+++ b/tmux.sh
@@ -13,9 +13,9 @@ tmux new-session -s $SNAME -d -x "$(tput cols)" -y "$(tput lines)"
 tmux send-keys -t $SNAME "python -m simoc_sam.sioserver" Enter
 # create 3 more panes for sensors/clients
 tmux split-window -h -p 75
-tmux send-keys -t $SNAME 'sleep 10' Enter "python -m simoc_sam.sensors.mocksensor -v" Enter
+tmux send-keys -t $SNAME 'sleep 3' Enter "python -m simoc_sam.sensors.mocksensor -v" Enter
 tmux split-window -v -p 67
-tmux send-keys -t $SNAME 'sleep 17' Enter "python -m simoc_sam.sioclient" Enter
+tmux send-keys -t $SNAME 'sleep 5' Enter "python -m simoc_sam.sioclient" Enter
 tmux split-window -v -p 50
 tmux send-keys -t $SNAME
 # focus on the server pane

--- a/tmux.sh
+++ b/tmux.sh
@@ -11,16 +11,13 @@ tmux new-session -s $SNAME -d -x "$(tput cols)" -y "$(tput lines)"
 # start the server in the first pane
 # tmux send-keys -t $SNAME "docker run --rm -it -p $SIOPORT:8080 -v `pwd`:/sioserver sioserver" Enter
 tmux send-keys -t $SNAME "python -m simoc_sam.sioserver" Enter
-# create 4 more panes and run the sensors and clients
-tmux split-window -h -p 65
-tmux send-keys -t $SNAME 'sleep 5' Enter "python -m simoc_sam.sensors.vernier -v" Enter
-tmux split-window -v
-tmux send-keys -t $SNAME 'sleep 12' Enter "python -m simoc_sam.sensors.scd30 -v" Enter
-tmux split-window -h -p 50
-tmux send-keys -t $SNAME 'sleep 17' Enter "python -m simoc_sam.sioclient" Enter
-tmux select-pane -t 1
-tmux split-window -h -p 50
+# create 3 more panes for sensors/clients
+tmux split-window -h -p 75
 tmux send-keys -t $SNAME 'sleep 10' Enter "python -m simoc_sam.sensors.mocksensor -v" Enter
+tmux split-window -v -p 67
+tmux send-keys -t $SNAME 'sleep 17' Enter "python -m simoc_sam.sioclient" Enter
+tmux split-window -v -p 50
+tmux send-keys -t $SNAME
 # focus on the server pane
 tmux select-pane -t 0
 # enable mouse input
@@ -29,10 +26,9 @@ tmux set -g mouse on
 tmux set -g pane-border-status top
 tmux set -g pane-border-format "#{pane_title}"
 tmux select-pane -t 0 -T "Server"
-tmux select-pane -t 1 -T "Vernier"
-tmux select-pane -t 2 -T "MockSensor"
-tmux select-pane -t 3 -T "SCD30"
-tmux select-pane -t 4 -T "Client 1"
+tmux select-pane -t 1 -T "MockSensor"
+tmux select-pane -t 2 -T "Client"
+tmux select-pane -t 3 -T "Shell"
 # attach to the session
 tmux attach-session -t $SNAME
 # deactivate venv when leaving


### PR DESCRIPTION
This PR improves the tmux layout to look like this:
![image](https://user-images.githubusercontent.com/25624924/233602844-2fd55a62-9027-48fc-9119-4fbb5479a807.png)

The server (on the left) now only prints a message every few broadcasts, without printing the actual readings.  It also prints how many sensors/clients are connected.  On the right there is a panel for the sensors (during mission-1 there will only be Vernier sensors), one for the sioclient/csv logger, and a shell (useful for debugging).  These 3 panels are now wider so that more data fit in one line.

I also commented out a few more redundant messages. 