### PR TITLE
Make server delay configurable.

### DIFF
--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -51,7 +51,7 @@ def get_addr_argparser():
 def parse_args(*, read_delay=1, port=8081):
     parser = get_addr_argparser()
     parser.add_argument('-d', '--read-delay', default=read_delay,
-                        dest='delay', metavar='DELAY', type=int,
+                        dest='delay', metavar='DELAY', type=float,
                         help='How many seconds between readings.')
     parser.add_argument('--no-sio', action='store_true',
                         help='Run the sensor without socketio.')

--- a/src/simoc_sam/sioserver.py
+++ b/src/simoc_sam/sioserver.py
@@ -152,6 +152,9 @@ def get_timestamp():
 
 async def emit_readings():
     """Emit a bundle with the latest reading of all sensors."""
+    args = utils.parse_args()  # TODO: create separate parser for the server
+    delay = args.delay
+    print(f'Broadcasting data every {delay} seconds.')
     n = 0
     while True:
         if SENSORS and SUBSCRIBERS:
@@ -166,14 +169,12 @@ async def emit_readings():
                 # the frontend expects a list of bundles
                 await emit_to_subscribers('step-batch', [bundle])
                 n += 1
-                if n%60 == 0:
-                    print(f'{len(SENSORS)} sensor(s); '
-                          f'{len(SUBSCRIBERS)} subscriber(s); '
-                          f'{n} readings broadcasted')
+                print(f'{len(SENSORS)} sensor(s); {len(SUBSCRIBERS)} '
+                      f'subscriber(s); {n} readings broadcasted')
             except Exception as e:
                 print('!!! Failed to emit step-batch:')
                 traceback.print_exc()
-        await sio.sleep(1)
+        await sio.sleep(delay)
 
 
 # app setup


### PR DESCRIPTION
This PR recycles the sensor arg parser in order to read the `-d` option for the delay.  This can be refactored later to a better server-specific arg parser, but for now it's good enough and allows us to set the broadcast delay from the cmdline.  It also allows float delays (useful for testing).

Note that eventually we should create rooms where data are broadcasted at different intervals (possibly requested by the clients themselves), so that we could have e.g. the csv logger in the 1s room reading and logging all the data, but the dashboard in the 10s room getting a reading every 10s.