### PR TITLE
Add the hostinfo.py script and the `info` command to simoc-sam.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ operations.  The script will automatically create a venv (virtual
 environment), install the dependencies, and run the commands inside
 the venv.
 
-You can see the full list of commands with `python simoc_sam.py -h`,
-and you can run them with `python simoc_sam.py COMMAND`:
+You can see the full list of commands with `python simoc-sam.py -h`,
+and you can run them with `python simoc-sam.py COMMAND`:
 * `run-server` will start the `sioserver`
 * `run-tmux` will start the `tmux.sh` script
 * `test` will execute the tests using `pytest`
+* `info` will print host info about the network and sensors
 
 
 ## Using the `venv` manually

--- a/hostinfo.py
+++ b/hostinfo.py
@@ -1,0 +1,108 @@
+import os
+import socket
+import netifaces
+import subprocess
+
+
+addr_types = {
+    'MAC': netifaces.AF_LINK,
+    'IPv4': netifaces.AF_INET,
+    'IPv6': netifaces.AF_INET6,
+}
+sensors = {
+    0x61: 'SCD30',
+    0x77: 'BME688',
+    0x58: 'SGP30',
+    0x39: 'APDS9960',
+    0x29: 'TSL2591',
+    0x10: 'VEML7700',
+}
+
+
+# Network info
+
+def print_hostname():
+    """Print current hostname."""
+    print(f'Hostname: {socket.gethostname()}')
+
+def print_addresses(ifaces_prefixes=('wl', 'bat', 'enp', 'eth')):
+    """Print MAC/IPv4/IPv6 addresses for WiFi/BATMAN/ethernet interfaces."""
+    interfaces = netifaces.interfaces()
+    found_ifaces = {}
+    for iface in interfaces:
+        if iface.startswith(ifaces_prefixes):
+            found_ifaces[iface] = netifaces.ifaddresses(iface)
+    if not found_ifaces:
+        print(f'No interface with the following prefixes found: {ifaces_prefixes}')
+        print(f'Available interfaces: {interfaces}')
+        return
+    print('IP/MAC addresses:')
+    for iface, addresses in found_ifaces.items():
+        print(f'* {iface}:')
+        for type, const in addr_types.items():
+            if const not in addresses:
+                continue
+            addr = addresses[const][0]['addr']
+            print(f'  {type:4}: {addr}')
+
+def print_batman():
+    """Print BATMAN info (neighbors/originators tables)."""
+    if not [iface for iface in netifaces.interfaces()
+            if iface.startswith('bat')]:
+        print('BATMAN: no interface detected')
+        return
+    print('BATMAN mesh:')
+    subprocess.run(['sudo', 'batctl', 'n'])
+    subprocess.run(['sudo', 'batctl', 'o'])
+
+
+# Sensors info
+
+def has_mcp():
+    return b'MCP2221' in subprocess.check_output("lsusb")
+
+def print_MCP2221_info():
+    """Print True if the MCP2221 is connected, False otherwise."""
+    print(f'MCP2221 connected: {has_mcp()}')
+
+def print_sensors():
+    """Print a list of connected sensors and their I2C addresses."""
+    if has_mcp():
+        os.environ['BLINKA_MCP2221'] = '1'
+        os.environ['BLINKA_MCP2221_RESET_DELAY'] = '-1'
+    try:
+        import board
+    except (ImportError, OSError):
+        print('Sensor scanning failed')
+        raise
+        return  # doesn't always work with RPi + MCP2221
+    import busio
+    i2c = busio.I2C(board.SCL, board.SDA)
+    devices = i2c.scan()
+    if not devices:
+        print('No sensors found')
+        return
+    print(f'Found {len(devices)} sensors:')
+    for i2c_addr in devices:
+        sensor_name = sensors.get(i2c_addr, '<unknown>')
+        print(f'* {sensor_name} (I2C addr: {i2c_addr:#x})')
+
+
+# Combined info
+def print_network_info():
+    print_hostname()
+    print_addresses()
+    print_batman()
+
+def print_sensors_info():
+    print_MCP2221_info()
+    print_sensors()
+
+def print_info():
+    print('===== Network info =====')
+    print_network_info()
+    print('===== Sensors info =====')
+    print_sensors_info()
+
+if __name__ == '__main__':
+    print_info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python-socketio
 aiohttp
+netifaces
 
 hidapi
 Adafruit-Blinka

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -7,6 +7,8 @@ import argparse
 import functools
 import subprocess
 
+import hostinfo
+
 
 SIMOC_SAM_DIR = pathlib.Path(__file__).resolve().parent
 VENV_DIR = SIMOC_SAM_DIR / 'venv'
@@ -87,6 +89,25 @@ def run_tmux():
         run(['tmux', 'attach-session', '-t', TMUX_SNAME])  # attach to sessions
     else:
         run(['./tmux.sh', TMUX_SNAME])  # start new sessions
+
+
+@cmd
+@needs_venv
+def info():
+    """Print host info about the network and sensors."""
+    hostinfo.print_info()
+
+@cmd
+@needs_venv
+def network_info():
+    """Print info about the network (hostname, addresses)."""
+    hostinfo.print_network_info()
+
+@cmd
+@needs_venv
+def sensors_info():
+    """Print info about the connected sensors."""
+    hostinfo.print_sensors_info()
 
 
 VERNIER_USB_RULES = """\

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -7,8 +7,6 @@ import argparse
 import functools
 import subprocess
 
-import hostinfo
-
 
 SIMOC_SAM_DIR = pathlib.Path(__file__).resolve().parent
 VENV_DIR = SIMOC_SAM_DIR / 'venv'
@@ -95,18 +93,21 @@ def run_tmux():
 @needs_venv
 def info():
     """Print host info about the network and sensors."""
+    import hostinfo
     hostinfo.print_info()
 
 @cmd
 @needs_venv
 def network_info():
     """Print info about the network (hostname, addresses)."""
+    import hostinfo
     hostinfo.print_network_info()
 
 @cmd
 @needs_venv
 def sensors_info():
     """Print info about the connected sensors."""
+    import hostinfo
     hostinfo.print_sensors_info()
 
 


### PR DESCRIPTION
This PR adds the `hostinfo.py` script and the `info`, `sensors-info`, `network-info` commands to `simoc-sam.py`.

The `hostinfo.py` can be run directly with `python3 hostinfo.py` (the `venv` must be active), or can be invoked using `python3 simoc-sam.py info`.

It will print something like:
```
===== Network info =====
Hostname: samrpi1
IP/MAC addresses:
* wlan0:
  MAC : e4:5f:01:b5:73:90
  IPv6: fe80::e65f:1ff:feb5:7390%wlan0
* bat0:
  MAC : 42:3d:94:c7:3e:30
  IPv4: 172.27.0.1
  IPv6: fe80::403d:94ff:fec7:3e30%bat0
===== Sensors info =====
MCP2221 connected: True
Found 2 sensors:
* SGP30 (I2C addr: 0x58)
* SCD30 (I2C addr: 0x61)
```

In addition, the `network-info` and `sensors-info` commands have been added to `simoc-sam.py` to print only network or sensors information.

These commands will help with troubleshooting and with host identification.