### PR TITLE
Add a `bash_aliases` file.

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -1,0 +1,14 @@
+# Create a symlink to this file in ~/.bash_aliases using:
+#   ln -s ~/simoc-sam/bash_aliases ~/.bash_aliases
+
+
+# ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# used to activate the venv
+alias activate='source venv/bin/activate'
+
+# run a simoc-sam.py command directly in the venv
+alias sam='~/simoc-sam/venv/bin/python3 ~/simoc-sam/simoc-sam.py'


### PR DESCRIPTION
This file contains aliases definition to make the use of `simoc-sam.py` and the RPi 0 in general simpler.
They can be installed by using `ln -s ~/simoc-sam/bash_aliases ~/.bash_aliases`.  `~/.bashrc` already looks for a `.bash_aliases` file and loads it automatically.  For some reason it already includes aliases for `ll`/`la`, but they are commented out.