### PR TITLE
Remove a conflicting argparse check.

### DIFF
--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -64,8 +64,6 @@ def parse_args(*, read_delay=1, port=8081):
     args = parser.parse_args()
     if args.verbose:
         args.verbose_sensor = args.verbose_sio = True
-    if args.no_sio and args.port is not None:
-        parser.error("Can't specify the socketio port with --no-sio.")
     if not args.no_sio and args.port is None:
         args.port = port
     return args


### PR DESCRIPTION
This PR fixes a bug that occurs when trying to use `--no-sio`.  The check verifies that no `port` value is set when running with `--no-sio`, however the port has a default value which is always set, making the use of `--no-sio` impossible.