### PR TITLE
Avoid using relative cwd in the copy-repo command.

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -76,8 +76,9 @@ def copy_repo(target):
     user, host, path = target_re.fullmatch(target).groups()
     user = user or 'pi'
     path = path or '/home/pi/simoc-sam'
+    repo = f'{pathlib.Path(__file__).parent}/'  # rsync wants the trailing /
     def rsync_cmd(user, host, path):
-        return ['rsync', '-avz', '.', f'{user}@{host}:{path}']
+        return ['rsync', '-avz', repo, f'{user}@{host}:{path}']
     try:
         subprocess.run(rsync_cmd(user, host, path),
                        check=True, stderr=subprocess.PIPE)


### PR DESCRIPTION
This PR changes the behavior of the `copy-repo` command so that instead of copying the cwd, it always copies the root of the repo.  Note that `rsync` behavior changes depending on whether the source has a trailing `/` or not:
* without trailing `/` it copies the directory with all its content
* with a trailing `/` it only copies the content

Here we want to copy/update the content of the `simoc-sam` dir, hence the trailing `/`.