### PR TITLE
Revert I2C initialization to avoid `get_sensor_i2c_bus()`.

### DIFF
--- a/src/simoc_sam/sensors/bme688.py
+++ b/src/simoc_sam/sensors/bme688.py
@@ -31,7 +31,7 @@ class BME688(BaseSensor):
     def __init__(self, *, name='BME688', **kwargs):
         """Initialize the sensor."""
         super().__init__(name=name, **kwargs)
-        i2c = utils.get_sensor_i2c_bus(0x77)
+        i2c = board.I2C()
         self.sensor = adafruit_bme680.Adafruit_BME680_I2C(i2c, debug=False)
 
     def read_sensor_data(self):

--- a/src/simoc_sam/sensors/scd30.py
+++ b/src/simoc_sam/sensors/scd30.py
@@ -29,8 +29,7 @@ class SCD30(BaseSensor):
     def __init__(self, *, name='SCD-30', description=None, verbose=False):
         """Initialize the sensor."""
         super().__init__(name=name, description=description, verbose=verbose)
-        i2c = utils.get_sensor_i2c_bus(0x61, board.SCL, board.SDA,
-                                       frequency=50000)
+        i2c = busio.I2C(board.SCL, board.SDA, frequency=50000)
         self.scd = adafruit_scd30.SCD30(i2c)
 
     def read_sensor_data(self):

--- a/src/simoc_sam/sensors/sgp30.py
+++ b/src/simoc_sam/sensors/sgp30.py
@@ -51,8 +51,7 @@ class SGP30(BaseSensor):
     def __init__(self, *, name='SGP30', verbose=False):
         """Initialize the sensor."""
         super().__init__(name=name, verbose=verbose)
-        i2c = utils.get_sensor_i2c_bus(0x58, board.SCL, board.SDA,
-                                       frequency=100000)
+        i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
         self.sensor = adafruit_sgp30.Adafruit_SGP30(i2c)
         self.sensor.iaq_init()
         self.sensor.set_iaq_baseline(0x8973, 0x8AEE)  # Numbers from adafruit example

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -29,6 +29,8 @@ def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
 
 def get_sensor_i2c_bus(sensor_i2c_addr, *args, **kwargs):
     import busio
+    # this method is currently unused as it requires
+    # https://github.com/adafruit/Adafruit_Blinka/pull/637 to work
     from adafruit_blinka.microcontroller.mcp2221.mcp2221 import MCP2221
 
     addresses = MCP2221.available_paths()


### PR DESCRIPTION
This is a follow-up of:
* #48 

#48 requires https://github.com/adafruit/Adafruit_Blinka/pull/637 in order to work, so the `get_sensor_i2c_bus()` function can't be used unless we install `Adafruit_Blinka` from my fork.