### PR TITLE
Fallback on system `python` if the venv is missing.

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -11,4 +11,4 @@ alias l='ls -CF'
 alias activate='source venv/bin/activate'
 
 # run a simoc-sam.py command directly in the venv
-alias sam='~/simoc-sam/venv/bin/python3 ~/simoc-sam/simoc-sam.py'
+alias sam='$(which ~/simoc-sam/venv/bin/python || which python3) ~/simoc-sam/simoc-sam.py'


### PR DESCRIPTION
The `sam` alias defined in `bash_aliases` uses the `python` defined in the venv, whether that's necessary or not.  This works fine for most commands, except `create-venv`, since the venv's `python` is not available and the command fails.

This PR tries to use the `python` defined in the venv, and if it doesn't exist it falls back on the system `python`.