### PR TITLE
Add `sensors.toml` and refactor the code to use it

### DIFF
--- a/hostinfo.py
+++ b/hostinfo.py
@@ -7,8 +7,6 @@ try:
 except ImportError:
     netifaces = None
 
-from simoc_sam.sensors.utils import I2C_TO_SENSOR
-
 
 # Network info
 
@@ -77,6 +75,7 @@ def print_sensors():
     except (AttributeError, ValueError) as err:
         print(f'Failed to access I2C bus: {err}')
         return
+    from simoc_sam.sensors.utils import I2C_TO_SENSOR
     devices = i2c.scan()
     if not devices:
         print('No sensors found.')

--- a/hostinfo.py
+++ b/hostinfo.py
@@ -52,22 +52,19 @@ def print_batman():
 
 # Sensors info
 
-def has_mcp():
-    return b'MCP2221' in subprocess.check_output("lsusb")
-
 def print_MCP2221_info():
     """Print True if the MCP2221 is connected, False otherwise."""
-    print(f'MCP2221 connected: {has_mcp()}')
+    from simoc_sam.sensors import utils
+    print(f'MCP2221 connected: {utils.has_mcp2221()}')
 
 def print_sensors():
     """Print a list of connected sensors and their I2C addresses."""
-    if has_mcp():
-        os.environ['BLINKA_MCP2221'] = '1'
-        os.environ['BLINKA_MCP2221_RESET_DELAY'] = '-1'
+    from simoc_sam.sensors import utils
+
     try:
-        import board
-    except (ImportError, OSError):
-        print('Sensor scanning failed.')
+        board = utils.import_board()
+    except (ImportError, OSError) as err:
+        print(f'Sensor scanning failed: {err}')
         return  # doesn't always work with RPi + MCP2221
     import busio
     try:
@@ -75,15 +72,14 @@ def print_sensors():
     except (AttributeError, ValueError) as err:
         print(f'Failed to access I2C bus: {err}')
         return
-    from simoc_sam.sensors.utils import I2C_TO_SENSOR
     devices = i2c.scan()
     if not devices:
         print('No sensors found.')
         return
     print(f'Found {len(devices)} sensors:')
     for i2c_addr in devices:
-        if i2c_addr in I2C_TO_SENSOR:
-            sensor_name = I2C_TO_SENSOR[i2c_addr].name
+        if i2c_addr in utils.I2C_TO_SENSOR:
+            sensor_name = utils.I2C_TO_SENSOR[i2c_addr].name
         else:
             sensor_name = '<unknown>'
         print(f'* {sensor_name} (I2C addr: {i2c_addr:#x})')

--- a/hostinfo.py
+++ b/hostinfo.py
@@ -7,15 +7,7 @@ try:
 except ImportError:
     netifaces = None
 
-sensors = {
-    0x61: 'SCD30',
-    0x62: 'SCD41',
-    0x77: 'BME688',
-    0x58: 'SGP30',
-    0x39: 'APDS9960',
-    0x29: 'TSL2591',
-    0x10: 'VEML7700',
-}
+from simoc_sam.sensors.utils import I2C_TO_SENSOR
 
 
 # Network info
@@ -91,7 +83,10 @@ def print_sensors():
         return
     print(f'Found {len(devices)} sensors:')
     for i2c_addr in devices:
-        sensor_name = sensors.get(i2c_addr, '<unknown>')
+        if i2c_addr in I2C_TO_SENSOR:
+            sensor_name = I2C_TO_SENSOR[i2c_addr].name
+        else:
+            sensor_name = '<unknown>'
         print(f'* {sensor_name} (I2C addr: {i2c_addr:#x})')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 python-socketio
 aiohttp
 netifaces
+tomli
 
+# sensor-related deps
 hidapi
 Adafruit-Blinka
 adafruit-circuitpython-scd30

--- a/src/simoc_sam/sensors/adafruit.py
+++ b/src/simoc_sam/sensors/adafruit.py
@@ -13,13 +13,6 @@ import busio
 
 from adafruit_blinka.microcontroller.mcp2221.mcp2221 import MCP2221
 
-device_to_i2c_addr = dict(
-    bme688=0x77,
-    sgp30=0x58,
-    scd30=0x61,
-)
-i2c_addr_to_device = dict(zip(device_to_i2c_addr.values(),
-                              device_to_i2c_addr.keys()))
 
 async def main():
     addresses = MCP2221.available_paths()
@@ -36,11 +29,11 @@ async def main():
         if i2c_devices:
             print(f'{len(i2c_devices)} device(s) found on <{address.decode()}>:')
             for i2c_addr in i2c_devices:
-                device = i2c_addr_to_device[i2c_addr]
-                print(f'  * {device} ({i2c_addr:#x})')
-                mod = importlib.import_module(f'simoc_sam.sensors.{device}')
+                device = utils.I2C_TO_SENSOR[i2c_addr]
+                print(f'  * {device.name} ({i2c_addr:#x})')
+                mod = importlib.import_module(device.module)
                 #print(f'Imported {mod}')
-                sensors_classes.append(getattr(mod, device.upper()))
+                sensors_classes.append(getattr(mod, device.name))
         else:
             print(f'No device found on <{address.decode()}>.')
             bus.deinit()

--- a/src/simoc_sam/sensors/sensors.toml
+++ b/src/simoc_sam/sensors/sensors.toml
@@ -1,0 +1,129 @@
+[scd30]
+name = "SCD30"
+description = "NDIR CO2, Temperature, and Humidity Sensor"
+module = "simoc_sam.sensors.scd30"
+i2c_address = 0x61
+
+    [scd30.data.CO2]
+    unit = "ppm"
+    label = "CO2 Concentration"
+
+    [scd30.data.temperature]
+    unit = "°C"
+    label = "Temperature"
+
+    [scd30.data.humidity]
+    unit = "%RH"
+    label = "Humidity"
+
+[scd41]
+name = "SCD41"
+description = "True CO2 Temperature and Humidity Sensor"
+module = "simoc_sam.sensors.scd4x"
+i2c_address = 0x62
+
+    [scd41.data.CO2]
+    unit = "ppm"
+    label = "CO2 Concentration"
+
+    [scd41.data.temperature]
+    unit = "°C"
+    label = "Temperature"
+
+    [scd41.data.humidity]
+    unit = "%RH"
+    label = "Humidity"
+
+[sgp30]
+name = "SGP30"
+description = "TVOC/eCO2 Gas Sensor"
+module = "simoc_sam.sensors.sgp30"
+i2c_address = 0x58
+
+    [sgp30.data.eCO2]
+    unit = "ppm"
+    label = "CO2 Equivalent Concentration"
+
+    [sgp30.data.TVOC]
+    unit = "ppb"
+    label = "Total Volatile Organic Compounds"
+
+    [sgp30.data.H2]
+    unit = "ppm"
+    label = "Hydrogen Concentration"
+
+    [sgp30.data.ethanol]
+    unit = "ppm"
+    label = "Ethanol Concentration"
+
+[bme688]
+name = "BME688"
+description = "Temperature, Humidity, Pressure, and Gas Sensor"
+module = "simoc_sam.sensors.bme688"
+i2c_address = 0x77
+
+    [bme688.data.temperature]
+    unit = "°C"
+    label = "Temperature"
+
+    [bme688.data.pressure]
+    unit = "hPa"
+    label = "Pressure"
+
+    [bme688.data.humidity]
+    unit = "%RH"
+    label = "Humidity"
+
+    [bme688.data.gas_resistance]
+    unit = "Ohm"
+    label = "Gas Resistance"
+
+    [bme688.data.altitude]
+    unit = "m"
+    label = "Altitude"
+
+[apds9960]
+name = "APDS9960"
+description = "Proximity, Light, RGB, and Gesture Sensor"
+module = ""
+i2c_address = 0x39
+
+    [apds9960.data.proximity]
+    unit = ""
+    label = "Proximity"
+
+    [apds9960.data.gesture]
+    unit = ""
+    label = "Gesture"
+
+    [apds9960.data.color]
+    unit = ""
+    label = "Color"
+
+[tsl2591]
+name = "TSL2591"
+description = "High Dynamic Range Digital Light Sensor"
+module = ""
+i2c_address = 0x29
+
+    [tsl2591.data.lux]
+    unit = "lux"
+    label = "Light Intensity"
+
+    [tsl2591.data.visible]
+    unit = ""
+    label = "Visible Light Level"
+
+    [tsl2591.data.infrared]
+    unit = ""
+    label = "Infrared Light Level"
+
+[veml7700]
+name = "VEML7700"
+description = "Ambient Light Sensor"
+module = ""
+i2c_address = 0x10
+
+    [veml7700.data.ambient_light]
+    unit = "Lux"
+    label = "Ambient Light"

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -78,10 +78,12 @@ def load_sensor_data(file_path=SENSORS_TOML):
 SENSOR_DATA = load_sensor_data()
 I2C_TO_SENSOR = {info.i2c_address: info for info in SENSOR_DATA.values()}
 
+def has_mcp2221():
+    return b'MCP2221' in subprocess.check_output("lsusb")
 
 def import_board():
     """Import the board module while checking for MCP2221s."""
-    if b'MCP2221' in subprocess.check_output("lsusb"):
+    if has_mcp2221():
         os.environ['BLINKA_MCP2221'] = '1'
         os.environ['BLINKA_MCP2221_RESET_DELAY'] = '-1'
     import board

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -1,11 +1,16 @@
 import os
+import pathlib
 import asyncio
 import argparse
 import subprocess
 
+from typing import Dict, Any
 from datetime import datetime
+from dataclasses import dataclass, field
 
 from .basesensor import SIOWrapper
+
+import tomli
 
 
 def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
@@ -44,6 +49,34 @@ def get_sensor_i2c_bus(sensor_i2c_addr, *args, **kwargs):
             return bus
         else:
             bus.deinit()
+
+
+@dataclass
+class SensorData:
+    name: str
+    description: str
+    module: str
+    i2c_address: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+SENSORS_TOML = pathlib.Path(__file__).with_name('sensors.toml')
+
+def load_sensor_data(file_path=SENSORS_TOML):
+    with open(file_path, 'rb') as f:
+        sensors = tomli.load(f)
+    sensor_data = {}
+    for sensor_name, sensor_info in sensors.items():
+        sensor_data[sensor_name] = SensorData(
+            name=sensor_info['name'],
+            description=sensor_info['description'],
+            module=sensor_info['module'],
+            i2c_address=sensor_info['i2c_address'],
+            data=sensor_info['data'],
+        )
+    return sensor_data
+
+SENSOR_DATA = load_sensor_data()
+I2C_TO_SENSOR = {info.i2c_address: info for info in SENSOR_DATA.values()}
 
 
 def import_board():


### PR DESCRIPTION
This PR adds a new `sensors.toml` file that includes data about sensors, e.g.:
```toml
[scd30]
name = "SCD30"
description = "NDIR CO2, Temperature, and Humidity Sensor"
module = "simoc_sam.sensors.scd30"
i2c_address = 0x61

    [scd30.data.CO2]
    unit = "ppm"
    label = "CO2 Concentration"

    [scd30.data.temperature]
    unit = "°C"
    label = "Temperature"

    [scd30.data.humidity]
    unit = "%RH"
    label = "Humidity"
```

It also includes a few utilities to access these info easily, and some code-refactoring to use them instead of hardcoded values.