### PR TITLE
Skip logging if the dir is not there.

### DIFF
--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -186,8 +186,11 @@ class MQTTWrapper:
 
     def log(self, payload):
         # TODO: implement better logging
-        with open(self.log_fname, 'a') as f:
-            f.write(f'{payload}\n')
+        try:
+            with open(self.log_fname, 'a') as f:
+                f.write(f'{payload}\n')
+        except FileNotFoundError as err:
+            self.print(f'Unable to write log file: {err}')
 
     def start(self, host, port):
         self.mqttc.loop_start()

--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -189,7 +189,7 @@ class MQTTWrapper:
         try:
             with open(self.log_fname, 'a') as f:
                 f.write(f'{payload}\n')
-        except FileNotFoundError as err:
+        except Exception as err:
             self.print(f'Unable to write log file: {err}')
 
     def start(self, host, port):


### PR DESCRIPTION
Logging doesn't work if the dir is not there.  This PR adds a try/except that skips the logging if it's missing.