### PR TITLE
Add driver for the TSL2591 sensor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ adafruit-circuitpython-scd30
 adafruit-circuitpython-scd4x
 adafruit-circuitpython-sgp30
 adafruit-circuitpython-bme680
+adafruit-circuitpython-tsl2591
 godirect

--- a/src/simoc_sam/sensors/sensors.toml
+++ b/src/simoc_sam/sensors/sensors.toml
@@ -155,7 +155,7 @@ description = "High Dynamic Range Digital Light Sensor"
 module = ""
 i2c_address = 0x29
 
-    [TSL2591.data.light]
+    [TSL2591.data.lux]
     unit = "lux"
     label = "Light"
     description = "Light Intensity"

--- a/src/simoc_sam/sensors/sensors.toml
+++ b/src/simoc_sam/sensors/sensors.toml
@@ -155,7 +155,7 @@ description = "High Dynamic Range Digital Light Sensor"
 module = ""
 i2c_address = 0x29
 
-    [TSL2591.data.lux]
+    [TSL2591.data.light]
     unit = "lux"
     label = "Light"
     description = "Light Intensity"

--- a/src/simoc_sam/sensors/tsl2591.py
+++ b/src/simoc_sam/sensors/tsl2591.py
@@ -1,0 +1,35 @@
+"""Driver for the TSL2591  sensor."""
+from . import utils
+from .basesensor import BaseSensor
+
+board = utils.import_board()
+
+import adafruit_tsl2591
+
+
+TSL2591_DATA = utils.SENSOR_DATA['TSL2591']
+
+class TSL2591(BaseSensor):
+    """Represent a TSL2591 sensor."""
+    sensor_type = TSL2591_DATA.name
+    reading_info = TSL2591_DATA.data
+
+    def __init__(self, *, name=None, description=None, verbose=False):
+        """Initialize the sensor."""
+        super().__init__(name=name, description=description, verbose=verbose)
+        i2c = board.I2C()
+        self.tsl = adafruit_tsl2591.TSL2591(i2c)
+
+    def read_sensor_data(self):
+        """Return sensor data (lux, visible, infrared) as a dict."""
+        reading = dict(
+            lux=self.tsl.lux,  # lux
+            visible=self.tsl.visible,  # int between 0-2147483647 (32-bit)
+            infrared=self.tsl.infrared,  # int between 0-65535 (16-bit)
+        )
+        self.print_reading(reading)
+        return reading
+
+
+if __name__ == '__main__':
+    utils.start_sensor(TSL2591)

--- a/src/simoc_sam/sensors/tsl2591.py
+++ b/src/simoc_sam/sensors/tsl2591.py
@@ -23,7 +23,7 @@ class TSL2591(BaseSensor):
     def read_sensor_data(self):
         """Return sensor data (lux, visible, infrared) as a dict."""
         reading = dict(
-            lux=self.tsl.lux,  # lux
+            light=self.tsl.lux,  # lux
             visible=self.tsl.visible,  # 32 bit int between 0-2147483647
             infrared=self.tsl.infrared,  # 16 bit int between 0-65535
         )

--- a/src/simoc_sam/sensors/tsl2591.py
+++ b/src/simoc_sam/sensors/tsl2591.py
@@ -1,4 +1,4 @@
-"""Driver for the TSL2591  sensor."""
+"""Driver for the TSL2591 light sensor."""
 from . import utils
 from .basesensor import BaseSensor
 
@@ -24,8 +24,8 @@ class TSL2591(BaseSensor):
         """Return sensor data (lux, visible, infrared) as a dict."""
         reading = dict(
             lux=self.tsl.lux,  # lux
-            visible=self.tsl.visible,  # int between 0-2147483647 (32-bit)
-            infrared=self.tsl.infrared,  # int between 0-65535 (16-bit)
+            visible=self.tsl.visible,  # 32 bit int between 0-2147483647
+            infrared=self.tsl.infrared,  # 16 bit int between 0-65535
         )
         self.print_reading(reading)
         return reading


### PR DESCRIPTION
This PR adds the driver for the [TSL2591 sensor](https://www.adafruit.com/product/1980).

The sensor exposes 3 readings:
* light (lux)
* visible (as a 32 bit int between 0-2147483647)
* infrared (as a 16 bit int between 0-65535)

This is a trimmed list with some sample readings and added inline comments that I just took in a dark room, only lit by a computer screen:
```py
$ python -m simoc_sam.sensors.tsl2591 -v -d1
# screen on a black terminal
[TSL2591] Light: 1.0lux: Visible: 196616: Infrared: 3
[TSL2591] Light: 1.2lux: Visible: 196616: Infrared: 3
# switched to GitHub (dark theme, slightly less black)
[TSL2591] Light: 2.0lux: Visible: 196623: Infrared: 3
[TSL2591] Light: 2.1lux: Visible: 196623: Infrared: 3
# switched to Wikipedia (blindly white background)
[TSL2591] Light: 10.4lux: Visible: 1048650: Infrared: 16
[TSL2591] Light: 10.4lux: Visible: 1048650: Infrared: 16
# back to the terminal
[TSL2591] Light: 1.0lux: Visible: 196616: Infrared: 3
[TSL2591] Light: 1.2lux: Visible: 196617: Infrared: 3
[TSL2591] Light: 1.2lux: Visible: 4194678: Infrared: 64
# turned on phone flashlight, and moved it at about 2cm in front of the sensor
[TSL2591] Light: 1610.9lux: Visible: 99494490: Infrared: 1560
[TSL2591] Light: 2295.4lux: Visible: 144915576: Infrared: 2211
[TSL2591] Light: 2415.7lux: Visible: 152256417: Infrared: 2323
[TSL2591] Light: 2377.8lux: Visible: 137247282: Infrared: 2094
# moved the light about 30cm away, at a 45º angle
[TSL2591] Light: 1142.0lux: Visible: 72162838: Infrared: 1013
[TSL2591] Light: 276.8lux: Visible: 20973421: Infrared: 320
[TSL2591] Light: 30.9lux: Visible: 3211485: Infrared: 49
[TSL2591] Light: 35.1lux: Visible: 3604728: Infrared: 55
# moved it again in front of the sensor, 2cm away
[TSL2591] Light: 75.4lux: Visible: 5440033: Infrared: 83
[TSL2591] Light: 91.5lux: Visible: 5964395: Infrared: 91
[TSL2591] Light: 96.6lux: Visible: 6226573: Infrared: 95
[TSL2591] Light: 102.5lux: Visible: 6554292: Infrared: 104
[TSL2591] Light: 2209.7lux: Visible: 139016753: Infrared: 2121
[TSL2591] Light: 2200.6lux: Visible: 142948896: Infrared: 2181
[TSL2591] Light: 2181.3lux: Visible: 131610360: Infrared: 2008
# moved it away from it and turned the flashlight off
[TSL2591] Light: 97.8lux: Visible: 6750873: Infrared: 101
[TSL2591] Light: 70.3lux: Visible: 5833192: Infrared: 89
[TSL2591] Light: 1.0lux: Visible: 196616: Infrared: 3
[TSL2591] Light: 1.0lux: Visible: 196616: Infrared: 3
[TSL2591] Light: 1.2lux: Visible: 196617: Infrared: 3
[TSL2591] Light: 0.8lux: Visible: 131078: Infrared: 2
# turned on medium power wall light
[TSL2591] Light: 4.2lux: Visible: 458782: Infrared: 7
[TSL2591] Light: 4.0lux: Visible: 458781: Infrared: 7
[TSL2591] Light: 4.0lux: Visible: 458781: Infrared: 7
[TSL2591] Light: 1.4lux: Visible: 131082: Infrared: 2
# turned off wall light
[TSL2591] Light: 0.6lux: Visible: 131077: Infrared: 2
[TSL2591] Light: 0.6lux: Visible: 131077: Infrared: 1
[TSL2591] Light: 0.9lux: Visible: 65542: Infrared: 1
# turned on strong ceiling light
[TSL2591] Light: 1.3lux: Visible: 196618: Infrared: 3
[TSL2591] Light: 11.1lux: Visible: 2490575: Infrared: 38
[TSL2591] Light: 29.5lux: Visible: 2490573: Infrared: 38
[TSL2591] Light: 29.5lux: Visible: 2490573: Infrared: 38
[TSL2591] Light: 29.5lux: Visible: 2490573: Infrared: 38
[TSL2591] Light: 29.5lux: Visible: 2490573: Infrared: 38
# turned off ceiling light
[TSL2591] Light: 0.6lux: Visible: 131077: Infrared: 2
[TSL2591] Light: 0.9lux: Visible: 65542: Infrared: 1
[TSL2591] Light: 0.6lux: Visible: 131077: Infrared: 2
[TSL2591] Light: 0.8lux: Visible: 131078: Infrared: 2
```

See also:
* #103