### PR TITLE
Add driver for the VEML7700 sensor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ adafruit-circuitpython-scd30
 adafruit-circuitpython-scd4x
 adafruit-circuitpython-sgp30
 adafruit-circuitpython-bme680
+adafruit-circuitpython-veml7700
 godirect

--- a/src/simoc_sam/sensors/sensors.toml
+++ b/src/simoc_sam/sensors/sensors.toml
@@ -177,6 +177,6 @@ module = ""
 i2c_address = 0x10
 
     [VEML7700.data.light]
-    unit = "Lux"
+    unit = "lux"
     label = "Light"
     description = "Ambient Light"

--- a/src/simoc_sam/sensors/veml7700.py
+++ b/src/simoc_sam/sensors/veml7700.py
@@ -1,0 +1,33 @@
+"""Driver for the VEML7700 light sensor."""
+from . import utils
+from .basesensor import BaseSensor
+
+board = utils.import_board()
+
+import adafruit_veml7700
+
+
+VEML7700_DATA = utils.SENSOR_DATA['VEML7700']
+
+class VEML7700(BaseSensor):
+    """Represent a VEML7700 sensor."""
+    sensor_type = VEML7700_DATA.name
+    reading_info = VEML7700_DATA.data
+
+    def __init__(self, *, name=None, description=None, verbose=False):
+        """Initialize the sensor."""
+        super().__init__(name=name, description=description, verbose=verbose)
+        i2c = board.I2C()
+        self.tsl = adafruit_veml7700.VEML7700(i2c)
+
+    def read_sensor_data(self):
+        """Return sensor data (light) as a dict."""
+        reading = dict(
+            light=self.tsl.light,  # lux
+        )
+        self.print_reading(reading)
+        return reading
+
+
+if __name__ == '__main__':
+    utils.start_sensor(VEML7700)


### PR DESCRIPTION
This PR adds the driver for the [VEML7700 sensor](https://www.adafruit.com/product/4162) (they also have a [right angle version](https://www.adafruit.com/product/5378) -- the driver should work with both).

The sensor exposes a single reading: light (in lux).

This is a trimmed list with some sample readings and added inline comments that I just took in a dark room, only lit by a computer screen:
```python
$ python -m simoc_sam.sensors.veml7700 -v -d1
# screen on a black terminal
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
# switched to GitHub (dark theme, slightly less black)
[VEML7700] Light: 7lux
[VEML7700] Light: 7lux
[VEML7700] Light: 7lux
# switched to Wikipedia (blindly white background)
[VEML7700] Light: 31lux
[VEML7700] Light: 31lux
[VEML7700] Light: 31lux
# back to the terminal
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
# turned on phone flashlight, and moved it at about 2cm in front of the sensor
[VEML7700] Light: 263lux
[VEML7700] Light: 2781lux
[VEML7700] Light: 4906lux
[VEML7700] Light: 10251lux
[VEML7700] Light: 9971lux
[VEML7700] Light: 9771lux
[VEML7700] Light: 7673lux
# moved the light about 30cm away, at a 45º angle
[VEML7700] Light: 2792lux
[VEML7700] Light: 1030lux
[VEML7700] Light: 444lux
[VEML7700] Light: 362lux
[VEML7700] Light: 245lux
[VEML7700] Light: 247lux
# moved it again in front of the sensor, 2cm away
[VEML7700] Light: 249lux
[VEML7700] Light: 490lux
[VEML7700] Light: 8146lux
[VEML7700] Light: 10381lux
# moved it away from it and turned the flashlight off
[VEML7700] Light: 8398lux
[VEML7700] Light: 1010lux
[VEML7700] Light: 223lux
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
[VEML7700] Light: 3lux
[VEML7700] Light: 4lux
# turned on medium power wall light
[VEML7700] Light: 15lux
[VEML7700] Light: 15lux
[VEML7700] Light: 15lux
[VEML7700] Light: 15lux
# turned off wall light
[VEML7700] Light: 4lux
[VEML7700] Light: 4lux
[VEML7700] Light: 4lux
[VEML7700] Light: 4lux
# turned on strong ceiling light
[VEML7700] Light: 6lux
[VEML7700] Light: 7lux
[VEML7700] Light: 102lux
[VEML7700] Light: 101lux
[VEML7700] Light: 101lux
[VEML7700] Light: 101lux
[VEML7700] Light: 102lux
# turned off ceiling light
[VEML7700] Light: 4lux
[VEML7700] Light: 4lux
[VEML7700] Light: 4lux

```

See also:
* #102 