### PR TITLE
Remove the SGP30 from `mqtt.sh`

### DIFF
--- a/tmux/mqtt.sh
+++ b/tmux/mqtt.sh
@@ -12,12 +12,10 @@ tmux new-session -s $SNAME -d -x "$(tput cols)" -y "$(tput lines)"
 tmux send-keys -t $SNAME
 # create 3 more panes for the sensors
 tmux split-window -h -p 75
-tmux send-keys -t $SNAME 'activate; sleep 1' Enter "python -m simoc_sam.sensors.scd30 -v --mqtt" Enter
-tmux split-window -v -p 67
-tmux send-keys -t $SNAME 'activate; sleep 3' Enter "python -m simoc_sam.sensors.sgp30 -v --mqtt" Enter
+tmux send-keys -t $SNAME 'activate' Enter "python -m simoc_sam.sensors.scd30 -v --mqtt" Enter
 tmux split-window -v -p 50
-tmux send-keys -t $SNAME 'activate; sleep 5' Enter "python -m simoc_sam.sensors.bme688 -v --mqtt" Enter
-# focus on the server pane
+tmux send-keys -t $SNAME 'activate' Enter "python -m simoc_sam.sensors.bme688 -v --mqtt" Enter
+# focus on the shell pane
 tmux select-pane -t 0
 # enable mouse input
 tmux set -g mouse on
@@ -26,8 +24,7 @@ tmux set -g pane-border-status top
 tmux set -g pane-border-format "#{pane_title}"
 tmux select-pane -t 0 -T "Shell"
 tmux select-pane -t 1 -T "SCD30"
-tmux select-pane -t 2 -T "SGP30"
-tmux select-pane -t 3 -T "BME688"
+tmux select-pane -t 2 -T "BME688"
 # attach to the session
 tmux attach-session -t $SNAME
 # deactivate venv when leaving


### PR DESCRIPTION
Due to hardware problems with the SGP30 sensors we got from Adafruit, we had to remove them from the sensor array.  This PR updates `mqtt.sh` (used to launch `tmux`) to remove the SGP30 pane.

According to https://forums.adafruit.com/viewtopic.php?t=212812 they fixed the issue, so if/when we get replacements and add the sensors back to the array we can revert this commit to get the pane back.