### PR TITLE
Add a systemd unit file to run sensors as services

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -7,3 +7,5 @@ This should be done through the `simoc-sam.py` script
 Files in this directory:
 * `simoc_live.tmpl`: Nginx configuration file that statically serves the
   frontend and redirect socketio traffic to the backend
+* `sensor-runner@.service`: `systemd` unit template file used to run the
+  sensor scripts on boot

--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -1,0 +1,26 @@
+# This unit file is used to launch the sensors scripts on boot.
+# Symlink it with `ln -s configs/sensor-runner@.service
+# /etc/systemd/system/sensor-runner@.service` before using.
+# Use e.g. `systemctl enable sensor-runner@scd30.service`
+# to enable the service.
+# Once symlinked and enabled for each sensor, the services will
+# start automatically on boot.
+# They can be controlled with `start`/`stop`/`restart`/`status`.
+# Use e.g. `journalctl -u sensor-runner@scd30.service -f` to
+# see the script output.
+
+[Unit]
+Description=%i sensor runner service
+After=network.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/simoc-sam
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.sensors.%i -v --mqtt
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -8,6 +8,8 @@
 # They can be controlled with `start`/`stop`/`restart`/`status`.
 # Use e.g. `journalctl -u sensor-runner@scd30.service -f` to
 # see the script output.
+# Use `journalctl -u 'sensor-runner@*' -f` to see the combined
+# output of all the sensors.
 
 [Unit]
 Description=%i sensor runner service


### PR DESCRIPTION
This is an alternative solution to:
* #110 

Instead of trying to launch `tmux` as a service, I created a unit file template that can be used to launch the individual sensor scripts as services, that can be enabled to automatically start on boot.  The logs can be inspected using e.g. `journalctl -u sensor-runner@scd30.service -f`, so technically a `tmux` script that launches `journalctl` could be created to inspect multiple logs at once.  This PR doesn't include this, and also doesn't include automation to (un)symlink this file.  This can be added in a separate PR.