### PR TITLE
Add a script to check for and re-establish network connectivity.

### DIFF
--- a/configs/network-monitor.service
+++ b/configs/network-monitor.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Network Monitor Service
+After=network.target
+
+[Service]
+ExecStart=/home/pi/simoc-sam/network_monitor.sh
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target
+

--- a/network_monitor.sh
+++ b/network_monitor.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script checks if the RPi is online.
+# If not, it restarts the network interface,
+# checks again, and if it's still offline,
+# it reboots the RPi
+
+# Define the IP address or hostname to check connectivity
+PING_TARGET="google.com"
+RETRY_COUNT=5
+INTERFACE="eth0"
+
+while true; do
+    echo "Checking ping results for eth0 restart"
+    # Ping the target
+    ping -c $RETRY_COUNT $PING_TARGET 
+    # Check if the ping was unsuccessful
+    if [ $? -ne 0 ]; then
+        echo "Network down. Restarting $INTERFACE..."
+        ip link set $INTERFACE down
+        sleep 10
+        ip link set $INTERFACE up
+        sleep 5
+        dhclient $INTERFACE 
+
+        
+        # Wait for some time to allow reconnection
+        sleep 20
+        
+        echo "Checking ping results for reboot"
+        # Ping again to see if the network is back up
+        ping -c $RETRY_COUNT $PING_TARGET 
+        if [ $? -ne 0 ]; then
+            echo "Network still down. Rebooting..."
+            reboot
+        fi
+    fi
+    
+    # Check the network status every 2 minutes
+    sleep 240
+done
+


### PR DESCRIPTION
This script checks for network connectivity by pinging Google every few minutes.
If the ping is not successful, the script will try to:
1. restart the network interface, and check again
2. if it's still not working, it will just reboot the pi

It can be installed by copying `network-monitor.service` to `/etc/systemd/system/` and launched with `sudo systemctl start network-monitor`.

This script was created to prevent the RPi4 from going offline, which is something that we observed a few times, but we still haven't figured out why it happens and how to fix it properly.  The PR doesn't need to be merged if we figure out and fix the root cause.

This script was developed by @fcarbogn.