### PR TITLE
Create mqttbridge.service

### DIFF
--- a/configs/mqttbridge.service
+++ b/configs/mqttbridge.service
@@ -9,7 +9,7 @@
 # Use e.g. `journalctl -u mqttbridge.service -f` to
 # see the script output.
 [Unit]
-Description= mqttbridge (forwarding data to simoc web) service
+Description=mqttbridge service to forward data to SIMOC web
 After=network.target
 
 [Service]

--- a/configs/mqttbridge.service
+++ b/configs/mqttbridge.service
@@ -1,0 +1,25 @@
+# This unit file is used to launch the mqttbridge scripts on boot.
+# Symlink it with `ln -s configs/mqttbridge.service
+# /etc/systemd/system/mqttbridge.service` before using.
+# Use e.g. `systemctl enable mqttbridge.service`
+# to enable the service.
+# Once symlinked and enabled for each sensor, the services will
+# start automatically on boot.
+# They can be controlled with `start`/`stop`/`restart`/`status`.
+# Use e.g. `journalctl -u mqttbridge.service -f` to
+# see the script output.
+[Unit]
+Description= mqttbridge (forwarding data to simoc web) service
+After=network.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/simoc-sam
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.mqttbridge
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a `systemd` service unit file to run the `src/simoc_sam/mqttbridge.py` script that forwards MQTT messages to SIMOC web via SocketIO.