### PR TITLE
Use `execvp` in `needs_root` to re-run the command as root

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -61,8 +61,10 @@ def needs_root(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
         if os.geteuid() != 0:
-            sys.exit('This commands needs to be executed as root.')
-        return func(*args, **kwargs)
+            os.execvp('sudo', ['sudo', sys.executable, *sys.argv])
+            return
+        else:
+            return func(*args, **kwargs)
     return inner
 
 def write_template(path, replacements):


### PR DESCRIPTION
This fixes #108 by using `execvp` to re-run the command as root when the command is decorated with the `@needs_root` decorator.  This means that the `sam` alias can be used directly without `sudo`, which is invoked when needed by `@needs_root`/`execvp`.