### PR TITLE
Enable dependabot for this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+
+  # Maintain dependencies for pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ezio-melotti"
+    open-pull-requests-limit: 10
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "ezio-melotti"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR is a follow-up of:
* #123 

and it enables dependabot for this repo in order to keep deps updated.