### PR TITLE
Add a command to install the touchscreen.

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -8,6 +8,7 @@ import shutil
 import socket
 import pathlib
 import argparse
+import tempfile
 import functools
 import subprocess
 
@@ -385,20 +386,16 @@ def add_usb_rules():
 
 
 @cmd
+@needs_root
 def install_touchscreen():
     """Install the GeeekPi 3.5" LCD touchscreen."""
-    home = pathlib.Path.home()
-    os.chdir(home)
     repo_name = 'LCD-show'
-    run(['git', 'clone', f'https://github.com/goodtft/{repo_name}.git'])
-    run(['chmod', '-R', '775', repo_name])
-    repo_path = home / repo_name
-    remove_on_boot(repo_path)  # schedule cleanup before running the script
-    run(['sudo', './MHS35-show'], cwd=repo_path)  # will reboot at the end
-
-def remove_on_boot(path):
-    # schedule removal of the specified path 1s after boot
-    run(['sudo', 'systemd-run', '--on-boot=1', 'rm', '-rf', str(path)])
+    repo_url = f'https://github.com/goodtft/{repo_name}.git'
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        repo_path = pathlib.Path(tmpdir_name) / repo_name
+        run(['git', 'clone', repo_url, str(repo_path)])  # clone repo
+        run(['chmod', '-R', '775', str(repo_path)])  # fix permissions
+        run([str(repo_path / 'MHS35-show')])  # install the touchscreen
 
 
 def create_help(cmds):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -396,7 +396,7 @@ def install_touchscreen():
         repo_path = pathlib.Path(tmpdir_name) / repo_name
         run(['git', 'clone', repo_url, str(repo_path)])  # clone repo
         run(['chmod', '-R', '775', str(repo_path)])  # fix permissions
-        run([str(repo_path / 'MHS35-show')])  # install the touchscreen
+        run([str(repo_path / 'MHS35-show')])  # install the screen and reboot
 
 
 def create_help(cmds):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -38,10 +38,10 @@ def cmd(func):
     COMMANDS[func.__name__] = func
     return func
 
-def run(args):
+def run(args, **kwargs):
     print('>>', ' '.join(args))
     print('-'*80)
-    result = subprocess.run(args)
+    result = subprocess.run(args, **kwargs)
     print('-'*80)
     print('<<', result)
     print()

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -384,6 +384,23 @@ def add_usb_rules():
     return add_vernier_rules() and add_mcp_rules()
 
 
+@cmd
+def install_touchscreen():
+    """Install the GeeekPi 3.5" LCD touchscreen."""
+    home = pathlib.Path.home()
+    os.chdir(home)
+    repo_name = 'LCD-show'
+    run(['git', 'clone', f'https://github.com/goodtft/{repo_name}.git'])
+    run(['chmod', '-R', '775', repo_name])
+    repo_path = home / repo_name
+    remove_on_boot(repo_path)  # schedule cleanup before running the script
+    run(['sudo', './MHS35-show'], cwd=repo_path)  # will reboot at the end
+
+def remove_on_boot(path):
+    # schedule removal of the specified path 1s after boot
+    run(['sudo', 'systemd-run', '--on-boot=1', 'rm', '-rf', str(path)])
+
+
 def create_help(cmds):
     help = ['Full list of available commands:']
     for cmd, func in cmds.items():

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -392,6 +392,7 @@ def install_touchscreen():
     repo_name = 'LCD-show'
     repo_url = f'https://github.com/goodtft/{repo_name}.git'
     with tempfile.TemporaryDirectory() as tmpdir_name:
+        os.chdir(tmpdir_name)
         repo_path = pathlib.Path(tmpdir_name) / repo_name
         run(['git', 'clone', repo_url, str(repo_path)])  # clone repo
         run(['chmod', '-R', '775', str(repo_path)])  # fix permissions


### PR DESCRIPTION
This `simoc-sam.py` installs the [GeeekPi 3.5" touchscreen for the Raspberry Pi 4/5](https://www.amazon.com/dp/B0D7VDWBBC).

In order to do that it will:
* clone https://github.com/goodtft/LCD-show.git
* make the whole repo executable (a bit sketchy, but the instructions says to do it)
* run the [`MHS35-show`](https://github.com/goodtft/LCD-show/blob/master/MHS35-show) script (that does more sketchy things to install the screen)
* schedule the repo to be deleted on boot (since the scripts reboots the Pi before `simoc-sam.py` does it)

This is currently untested, but will test it and report back shortly.