### PR TITLE
Add an `initial-setup` command to `simoc-sam.py`

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -402,16 +402,19 @@ def install_touchscreen():
 @cmd
 def initial_setup():
     """Perform the initial setup of the Raspberry Pi."""
+    print('Instaling bash aliases...')
     install_bash_aliases()
+    print('Removing empty home dirs...')
     remove_home_dirs()
     install_deps()
+    print('System updated, deps installed, aliases set up.')
+    print('Run <source ~/.bash_aliases> to install the aliases now.')
 
 def install_bash_aliases():
     """Install the .bash_aliases file in the home dir."""
     fname = 'bash_aliases'
     try:
         (HOME / f'.{fname}').symlink_to(SIMOC_SAM_DIR / fname)
-        print(f'Run this to install the aliases now: source ~/.{fname}')
     except FileExistsError:
         print(f'<~/.{fname}> already exists!')
 

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -408,12 +408,12 @@ def initial_setup():
 
 def install_bash_aliases():
     """Install the .bash_aliases file in the home dir."""
-    fname = '.bash_aliases'
+    fname = 'bash_aliases'
     try:
-        (HOME / fname).symlink_to(SIMOC_SAM_DIR / fname)
-        print(f'Run this to install the aliases now: source {fname}')
+        (HOME / f'.{fname}').symlink_to(SIMOC_SAM_DIR / fname)
+        print(f'Run this to install the aliases now: source ~/.{fname}')
     except FileExistsError:
-        print(f'<.bash_aliases> already exists!')
+        print(f'<~/.{fname}> already exists!')
 
 def remove_home_dirs():
     """Remove unused default directories from the user's home."""

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -406,8 +406,9 @@ def initial_setup():
     install_bash_aliases()
     print('Removing empty home dirs...')
     remove_home_dirs()
+    print('Updating system and installing deps...')
     install_deps()
-    print('System updated, deps installed, aliases set up.')
+    print('System updated, deps installed, home cleaned, aliases set up.')
     print('Run <source ~/.bash_aliases> to install the aliases now.')
 
 def install_bash_aliases():


### PR DESCRIPTION
This PR adds an `initial-setup` command to `simoc-sam.py` that:
* installs the `.bash_aliases` (fixes #96)
* removes default home directories (`Documents`, `Pictures`, `Videos`, etc.)
* updates the system and installs missing dependencies (see #65 and #95)

In the future we can expand this command to do additional things (such as updating `/etc/hosts`).