### PR TITLE
Set 960x640 as default res for the 3.5" screen

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -392,11 +392,14 @@ def install_touchscreen():
     repo_name = 'LCD-show'
     repo_url = f'https://github.com/goodtft/{repo_name}.git'
     with tempfile.TemporaryDirectory() as tmpdir_name:
-        os.chdir(tmpdir_name)
+        os.chdir(tmpdir_name)  # the script creates files in the cwd
         repo_path = pathlib.Path(tmpdir_name) / repo_name
+        script_path = repo_path / 'MHS35-show'
         run(['git', 'clone', repo_url, str(repo_path)])  # clone repo
+        run(['sed', '-i', '-e', '/hdmi_cvt / s/480 320/960 640/',
+             str(script_path)])  # update res (also: fbset -xres 960 -yres 640)
         run(['chmod', '-R', '775', str(repo_path)])  # fix permissions
-        run([str(repo_path / 'MHS35-show')])  # install the screen and reboot
+        run([str(script_path)])  # install the screen and reboot
 
 
 def create_help(cmds):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -393,10 +393,10 @@ def install_touchscreen():
     repo_name = 'LCD-show'
     repo_url = f'https://github.com/goodtft/{repo_name}.git'
     with tempfile.TemporaryDirectory() as tmpdir_name:
-        os.chdir(tmpdir_name)  # the script creates files in the cwd
         repo_path = pathlib.Path(tmpdir_name) / repo_name
         script_path = repo_path / 'MHS35-show'
         run(['git', 'clone', repo_url, str(repo_path)])  # clone repo
+        os.chdir(repo_path)  # the script creates files in the cwd
         run(['sed', '-i', '-e', '/hdmi_cvt / s/480 320/960 640/',
              str(script_path)])  # update res (also: fbset -xres 960 -yres 640)
         run(['chmod', '-R', '775', str(repo_path)])  # fix permissions


### PR DESCRIPTION
This is a follow-up of:
* #130 

Instead of using the default 480x320 resolution (which is quite cramped), it doubles it to 960x320.  Even though the screen only has 480x320 pixels, the image is then downscaled automatically but looks fine, and the screen can still fit 4 times more things.

We could also add a command to change the resolution that calls e.g. `fbset -xres 960 -yres 640`, but so far it doesn't seem particularly useful.