### PR TITLE
Temporary revert Adafruit-Blinka to 8.56.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tomli==2.2.1
 
 # sensor-related deps
 hidapi==0.14.0.post4
-Adafruit-Blinka==8.58.1
+Adafruit-Blinka==8.56.0
 adafruit-circuitpython-scd30==2.2.13
 adafruit-circuitpython-scd4x==1.4.5
 adafruit-circuitpython-sgp30==3.0.10


### PR DESCRIPTION
`Adafruit-Blinka` 8.57.0 doesn't work on the RPi 0s, so revert back to 8.56.0.
Adafruit is working on it, but as of 8.60.3 the issue is still not fixed.