### PR TITLE
Add the `services-info` command to `simoc-sam.py`

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -349,6 +349,12 @@ def sensors_info():
     hostinfo.print_sensors_info()
 
 @cmd
+def services_info():
+    """Print status of SIMOC-SAM services and key system services."""
+    import hostinfo
+    hostinfo.print_services()
+
+@cmd
 def hosts(target=None):
     """Print info about the other hosts in the network."""
     import netinfo

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -350,7 +350,7 @@ def sensors_info():
 
 @cmd
 def services_info():
-    """Print status of SIMOC-SAM services and key system services."""
+    """Print status of SIMOC Live services and key system services."""
     import hostinfo
     hostinfo.print_services()
 


### PR DESCRIPTION
This PR adds a `services-info` command that:
* prints a list of relevant running services and whether they are active or not, enabled or not, have errors or not;
* prints a list of relevant services that are not running;
* prints a list of commands that can be used to investigate errors, if any;

Relevant services include all services defined by SIMOC Live itself (stored in the `configs` dir) and some system services that are needed to run SIMOC Live.

A couple of examples of the output:
```
===== Services info =====
Service name              | Active         | Enabled    | Errors
--------------------------+----------------+------------+--------
avahi-daemon              | 🟢active       | 🟢enabled  | 
systemd-timesyncd         | 🟢active       | 🟢enabled  | 
--------------------------+----------------+------------+--------
* Inactive services: chrony, mosquitto, mqttbridge, sensor-runner@
```

```
===== Services info =====
Service name              | Active         | Enabled    | Errors
--------------------------+----------------+------------+--------
avahi-daemon              | 🟢active       | 🟢enabled  | 
sensor-runner@            |                |            |
  sensor-runner@sgp30     | 🟢active       | 🔴disabled | ⚠
  sensor-runner@bme688    | 🟢active       | 🟢enabled  | 
  sensor-runner@scd30     | 🟢active       | 🟢enabled  | 
systemd-timesyncd         | 🟢active       | 🟢enabled  | 
--------------------------+----------------+------------+--------
* Inactive services: chrony, mosquitto
* 1 service(s) with errors. Run the following command(s) to see the logs:
  journalctl -u sensor-runner@sgp30 --no-pager -n 100

```