### PR TITLE
Add a tmux script for the sensors

### DIFF
--- a/tmux/mqtt.sh
+++ b/tmux/mqtt.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# Starts a tmux session with a Mock sensor generating data, a SIO bridge
+# Start a tmux session with a Mock sensor generating data, a SIO bridge
 # that receives the MQTT data and converts them for Socket IO, and an
-# SIO client that receives them.  Requires tmux and an MQTT broker (mosquitto).
+# SIO client that receives and prints them.
+# Requires tmux and an MQTT broker (mosquitto).
 # Launch with `sam run-tmux mqtt`.
 
 # set vars

--- a/tmux/sensors.sh
+++ b/tmux/sensors.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Starts a tmux session with 4 panes, one for each sensor (SCD30, BMe688, SGP30)
+# Start a tmux session with 4 panes, one for each sensor (SCD30, BME688, SGP30)
 # and an empty terminal (for a 4th sensor, debugging, etc.)
 # Requires tmux and an MQTT broker (mosquitto).
 # Launch with `sam run-tmux sensors`.

--- a/tmux/sensors.sh
+++ b/tmux/sensors.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Starts a tmux session with 4 panes, one for each sensor (SCD30, BMe688, SGP30)
+# and an empty terminal (for a 4th sensor, debugging, etc.)
+# Requires tmux and an MQTT broker (mosquitto).
+# Launch with `sam run-tmux sensors`.
+
+# set vars
+SNAME=${1:-SAM}  # use provided session name or SAM as default
+export MQTTSERVER_ADDR=localhost:1883
+# create a new session and set the num of cols/lines
+tmux new-session -s $SNAME -d -x "$(tput cols)" -y "$(tput lines)"
+# Create 4 panes for the 3 sensors + a terminal
+tmux send-keys -t $SNAME 'activate' Enter "python -m simoc_sam.sensors.scd30 -v --mqtt" Enter
+tmux split-window -v
+tmux send-keys -t $SNAME 'activate' Enter "python -m simoc_sam.sensors.bme688 -v --mqtt" Enter
+tmux split-window -v
+tmux send-keys -t $SNAME 'activate' Enter "python -m simoc_sam.sensors.sgp30 -v --mqtt" Enter
+tmux split-window -v
+tmux send-keys -t $SNAME 'activate' Enter
+# set the layout to 4 equal rows
+tmux select-layout even-vertical
+# enable mouse input
+tmux set -g mouse on
+# set the title for the panes and show it on top
+tmux set -g pane-border-status top
+tmux set -g pane-border-format "#{pane_title}"
+tmux select-pane -t 0 -T "SCD30"
+tmux select-pane -t 1 -T "BME688"
+tmux select-pane -t 2 -T "SGP30"
+tmux select-pane -t 3 -T "Terminal"
+# attach to the session
+tmux attach-session -t $SNAME


### PR DESCRIPTION
This PR adds a new tmux script that opens for panes and runs the 3 standard sensors (SCD30, BME688, SGP30) + a 4th empty pane (for debugging, etc.).