### PR TITLE
Add a command to start the systemd services for the sensors

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -245,19 +245,6 @@ def teardown_nmconn(nmconn_file):
         run(['systemctl', 'disable', 'NetworkManager'])
 
 
-@cmd
-@needs_root
-def setup_siobridge():
-    """Setup a systemd service that runs the siobridge."""
-    setup_systemd_service('siobridge')
-
-@cmd
-@needs_root
-def teardown_siobridge():
-    """Revert the changes made by the setup-siobridge command."""
-    teardown_systemd_service('siobridge')
-
-
 def setup_systemd_service(name):
     # create a symlink to the given service, enable it, and start it
     service_name = f'{name}.service'
@@ -272,6 +259,19 @@ def teardown_systemd_service(name):
     run(['systemctl', 'stop', name])
     run(['systemctl', 'disable', name])
     pathlib.Path(SYSTEMD_DIR / f'{name}.service').unlink(missing_ok=True)
+
+
+@cmd
+@needs_root
+def setup_siobridge():
+    """Setup a systemd service that runs the siobridge."""
+    setup_systemd_service('siobridge')
+
+@cmd
+@needs_root
+def teardown_siobridge():
+    """Revert the changes made by the setup-siobridge command."""
+    teardown_systemd_service('siobridge')
 
 
 @cmd

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -247,8 +247,12 @@ def teardown_nmconn(nmconn_file):
 
 def setup_systemd_service(name):
     # create a symlink to the given service, enable it, and start it
+    if '@' in name:
+        target_name = f'{name.split("@")[0]}@.service'
+    else:
+        target_name = f'{name}.service'
     service_name = f'{name}.service'
-    (SYSTEMD_DIR / service_name).symlink_to(CONFIGS_DIR / service_name)
+    (SYSTEMD_DIR / service_name).symlink_to(CONFIGS_DIR / target_name)
     if not run(['systemctl', 'is-enabled', name]):
         run(['systemctl', 'enable', name])
     if not run(['systemctl', 'is-active', name]):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -267,6 +267,25 @@ def teardown_systemd_service(name):
 
 @cmd
 @needs_root
+def setup_sensors(sensors=None):
+    """Setup systemd services that run the sensors."""
+    if sensors:
+        sensors = sensors.split(',')
+    else:
+        sensors = config.sensors
+    for sensor in sensors:
+        setup_systemd_service(f'sensor-runner@{sensor}')
+
+@cmd
+@needs_root
+def teardown_sensors():
+    """Revert the changes made by the setup-sensors command."""
+    for sensor in config.sensors:
+        teardown_systemd_service(f'sensor-runner@{sensor}')
+
+
+@cmd
+@needs_root
 def setup_siobridge():
     """Setup a systemd service that runs the siobridge."""
     setup_systemd_service('siobridge')
@@ -452,7 +471,7 @@ def install_deps():
 @cmd
 def create_config():
     """Create a user config file in ~/.config/simoc-sam/ and a symlink to it."""
-    # create simoc-sam dir in .~/.config
+    # create simoc-sam dir in ~/.config
     config_dir = HOME / '.config' / 'simoc-sam'
     config_dir.mkdir(parents=True, exist_ok=True)
     # copy the default config.py file in there

--- a/src/simoc_sam/defaults.py
+++ b/src/simoc_sam/defaults.py
@@ -7,7 +7,8 @@ with a symlink pointing to it for easier editing/discoverability.
 from pathlib import Path
 
 
-# Data collection
+# Sensors and data collection
+sensors = ['bme688', 'scd30', 'sgp30']
 sensor_read_delay = 10.0
 
 


### PR DESCRIPTION
This PR adds a `setup_sensors` command that:
* accepts a list of sensors names (or uses the default list from the config)
* creates a systemd unit file for each sensor
* enables and starts the service for each sensor 

The `teardown_sensors` does the opposite.

`sam start-sensors` will automatically start the list of sensors specified in the config (default: `scd30,sgp30,bme688`).
`sam start-sensors tsl2591,bno085` will start the TSL2591 and BNO085 sensors.
`sam services-info` can be used to verify the status of the services.