### PR TITLE
Fix systemd services not restarting on boot

### DIFF
--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -1,11 +1,8 @@
 # This unit file is used to launch the sensors scripts on boot.
-# Symlink it with `ln -s configs/sensor-runner@.service
-# /etc/systemd/system/sensor-runner@.service` before using.
-# Use e.g. `systemctl enable sensor-runner@scd30.service`
-# to enable the service.
-# Once symlinked and enabled for each sensor, the services will
-# start automatically on boot.
-# They can be controlled with `start`/`stop`/`restart`/`status`.
+# Use the `sam setup-sensors` command to start and enable the services
+# so that they start automatically on boot; `sam teardown-sensors`
+# to stop and disable the services.
+# Manually, they can be controlled with `start`/`stop`/`restart`/`status`.
 # Use e.g. `journalctl -u sensor-runner@scd30.service -f` to
 # see the script output.
 # Use `journalctl -u 'sensor-runner@*' -f` to see the combined

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -268,21 +268,26 @@ def teardown_systemd_service(name):
 
 @cmd
 @needs_root
-def setup_sensors(sensors=None):
+def setup_or_teardown_sensors(function, sensors=None):
     """Setup systemd services that run the sensors."""
     if sensors:
         sensors = sensors.split(',')
     else:
         sensors = config.sensors
     for sensor in sensors:
-        setup_systemd_service(f'sensor-runner@{sensor}')
+        function(f'sensor-runner@{sensor}')
 
 @cmd
 @needs_root
-def teardown_sensors():
+def setup_sensors(sensors=None):
+    """Setup systemd services that run the sensors."""
+    setup_or_teardown_sensors(setup_systemd_service, sensors)
+
+@cmd
+@needs_root
+def teardown_sensors(sensors=None):
     """Revert the changes made by the setup-sensors command."""
-    for sensor in config.sensors:
-        teardown_systemd_service(f'sensor-runner@{sensor}')
+    setup_or_teardown_sensors(teardown_systemd_service, sensors)
 
 
 @cmd

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -251,11 +251,13 @@ def setup_systemd_service(name):
         target_name = f'{name.split("@")[0]}@.service'
     else:
         target_name = f'{name}.service'
+    target_path = CONFIGS_DIR / target_name
     service_path = SYSTEMD_DIR / f'{name}.service'
     if service_path.exists():
         print(f'{service_path} already exists -- recreating it...')
         service_path.unlink()
-    service_path.symlink_to(CONFIGS_DIR / target_name)
+    service_path.symlink_to(target_path)
+    print(f'Created symlink {service_path} → {target_path}.')
     run(['systemctl', 'enable', name])  # ensure that the service starts on boot
     run(['systemctl', 'start', name])
 

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -256,10 +256,8 @@ def setup_systemd_service(name):
         print(f'{service_path} already exists -- recreating it...')
         service_path.unlink()
     service_path.symlink_to(CONFIGS_DIR / target_name)
-    if not run(['systemctl', 'is-enabled', name]):
-        run(['systemctl', 'enable', name])
-    if not run(['systemctl', 'is-active', name]):
-        run(['systemctl', 'start', name])
+    run(['systemctl', 'enable', name])  # ensure that the service starts on boot
+    run(['systemctl', 'start', name])
 
 def teardown_systemd_service(name):
     # stop, disable, and remove the symlink to the given service


### PR DESCRIPTION
This PR fixes a bug that prevented the services to automatically restart on boot.

Before, the `setup_systemd_service` did the following things:
1. create a symlink pointing to the unit (template) file
2. check if the service was enabled and, if not, enable it
3. check if the service was active and, if not, start it

During 1., a symlink in `/etc/systemd/system` was manually created, however this is apparently enough to enable the service (`is-enabled` returned `true`).  Because of this, during 2., the service was not enabled.  Enabling the service creates another symlink in `/etc/systemd/system/multi-user.target.wants/` which is responsible for starting the service on boot, but since the `enable` command was skipped, this was not happening.  Since both `enable` and `start` are idempotent (i.e. nothing happens if the service is already enabled/active), I now removed the `is-enabled` and `is-active` checks.

----

While working on this, I also discovered the `link` command that would simplify the creation of the symlink, however it doesn't support changing the name of the symlink.

Currently we create a symlink like `/etc/systemd/system/sensor-runner@scd30.service` -> `configs/sensor-runner@.service`, so that we have a unit for a specific sensor (`scd30` in this case) pointing to the template.  During the teardown, removing that symlink is enough to clean up everything that was created.

If we used the `link` command, instead of having a unit for each specific sensor in `/etc/systemd/system` (all pointing to the same template), we would have `/etc/systemd/system/sensor-runner@.service` -> `configs/sensor-runner@.service`, i.e. only the template would end up in `/etc/systemd/system`.  Enabling individual sensors (with e.g. `systemctl enable sensor-runner@scd30.service`) would correctly create another symlink like `/etc/systemd/system/multi-user.target.wants/sensor-runner@scd30.service` -> `configs/sensor-runner@.service` (which is automatically removed with the `disable` command).

The problem with this approach is that `/etc/systemd/system/sensor-runner@.service` can't be removed until any sensor service exists in `/etc/systemd/system/multi-user.target.wants/`.  Currently if we want to teardown the scd30 service(s), we can just run `disable` (that removes `/etc/systemd/system/multi-user.target.wants/sensor-runner@scd30.service`) and then manually remove `/etc/systemd/system/sensor-runner@scd30.service`.  If we used `link` we would have to first run `disable`, then check if there is any other `/etc/systemd/system/multi-user.target.wants/sensor-runner@*.service` unit (using something like `systemctl list-unit-files | grep sensor-runner@` or `systemctl list-units --all | grep sensor-runner@`) and then manually remove `/etc/systemd/system/sensor-runner@.service`.