### PR TITLE
Move logging from `MQTTWrapper` to `BaseSensor`

### DIFF
--- a/src/simoc_sam/defaults.py
+++ b/src/simoc_sam/defaults.py
@@ -7,13 +7,18 @@ with a symlink pointing to it for easier editing/discoverability.
 from pathlib import Path
 
 
+# HAB info
+location = 'sam'
+humans = 4
+volume = 272
+
+
 # Sensors and data collection
 sensors = ['bme688', 'scd30', 'sgp30']
 sensor_read_delay = 10.0
 
 
 # MQTT configuration
-mqtt_topic_location = 'sam'
 mqtt_host = 'localhost'
 mqtt_port = 1883
 mqtt_reconnect_delay = 5.0
@@ -22,7 +27,7 @@ mqtt_reconnect_delay = 5.0
 # SIMOC Web / SIO bridge configuration
 sio_host = 'localhost'
 sio_port = 8081
-mqtt_topic_sub = f'{mqtt_topic_location}/#'
+mqtt_topic_sub = f'{location}/#'
 simoc_web_port = 8080  # used for CORS validation
 simoc_web_dist_dir = Path.home() / 'dist'
 
@@ -32,12 +37,3 @@ verbose_sensor = False
 verbose_mqtt = False
 enable_jsonl_logging = True
 log_dir = Path.home() / 'logs'
-
-
-# HAB info
-humans = 4
-volume = 272
-
-
-# remove non-config vars
-del Path

--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -39,6 +39,11 @@ class BaseSensor(ABC):
         self.verbose = verbose
         # the total number of values read through iter_readings
         self.reading_num = 0
+        hostname = socket.gethostname()
+        fname = f'{config.location}_{hostname}_{self.sensor_name}.jsonl'
+        self.log_path = config.log_dir / fname
+        if config.enable_jsonl_logging:
+            config.log_dir.mkdir(exist_ok=True)  # ensure the log dir exists
 
     def __enter__(self):
         # use this to initialize the sensor and return self
@@ -67,7 +72,16 @@ class BaseSensor(ABC):
         if self.verbose:
             print(*args, **kwargs)
 
+    def log(self, payload):
+        try:
+            with open(self.log_path, 'a') as f:
+                f.write(f'{payload}\n')
+        except Exception as err:
+            self.print(f'Unable to write log file: {err}')
+
     def print_reading(self, reading):
+        if config.enable_jsonl_logging:
+            self.log(json.dumps(reading))
         data = []
         for name, info in self.reading_info.items():
             if name not in reading:
@@ -118,7 +132,7 @@ class BaseSensor(ABC):
 
 class MQTTWrapper:
     def __init__(self, sensor, *, read_delay=config.sensor_read_delay,
-                 verbose=config.verbose_sensor, location=config.mqtt_topic_location):
+                 verbose=config.verbose_sensor, location=config.location):
         self.sensor = sensor
         self.read_delay = read_delay  # how long to wait between readings
         self.verbose = verbose  # toggle verbose output
@@ -129,24 +143,11 @@ class MQTTWrapper:
         mqttc.on_disconnect = self.on_disconnect
         hostname = socket.gethostname()
         self.topic = f'{location}/{hostname}/{sensor.sensor_name}'
-        self.log_fname = config.log_dir / f'{self.topic.replace("/", "_")}.jsonl'
-        if config.enable_jsonl_logging:
-            config.log_dir.mkdir(exist_ok=True)  # ensure the log dir exists
 
     def print(self, *args, **kwargs):
         """Receive and print if self.verbose is true."""
         if self.verbose:
             print(*args, **kwargs)
-
-    def log(self, payload):
-        # TODO: implement better logging
-        if not config.enable_jsonl_logging:
-            return
-        try:
-            with open(self.log_fname, 'a') as f:
-                f.write(f'{payload}\n')
-        except Exception as err:
-            self.print(f'Unable to write log file: {err}')
 
     def start(self, host, port):
         self.mqttc.loop_start()
@@ -191,7 +192,6 @@ class MQTTWrapper:
             try:
                 jreading = json.dumps(reading)
                 self.mqttc.publish(self.topic, payload=jreading)
-                self.log(jreading)  # TODO: move this somewhere else
                 self.print(reading)
             except Exception as err:
                 self.print(f'No longer connected to the server ({err})...')

--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -80,8 +80,6 @@ class BaseSensor(ABC):
             self.print(f'Unable to write log file: {err}')
 
     def print_reading(self, reading):
-        if config.enable_jsonl_logging:
-            self.log(json.dumps(reading))
         data = []
         for name, info in self.reading_info.items():
             if name not in reading:
@@ -121,6 +119,8 @@ class BaseSensor(ABC):
                 data['timestamp'] = self.get_timestamp()
             if add_n:
                 data['n'] = self.reading_num
+            if config.enable_jsonl_logging:
+                self.log(json.dumps(data))
             yield data
             self.reading_num += 1
             if not read_forever:

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -142,7 +142,7 @@ def start_sensor(sensor_cls, *pargs, **kwargs):
     with sensor_cls(verbose=args.verbose_sensor, *pargs, **kwargs) as sensor:
         if args.mqtt:
             delay, verbose = args.delay, args.verbose_mqtt
-            location = config.mqtt_topic_location
+            location = config.location
             host, port = args.host, args.port
             mqttwrapper = MQTTWrapper(sensor, read_delay=delay, verbose=verbose,
                                       location=location)

--- a/tests/test_basesensor.py
+++ b/tests/test_basesensor.py
@@ -1,7 +1,7 @@
 import time
-import socket
+import json
 
-from unittest.mock import AsyncMock, MagicMock, patch, Mock
+from unittest.mock import patch
 
 import pytest
 
@@ -17,6 +17,7 @@ class MySensor(BaseSensor):
     sensor_type = 'TestSensor'
     reading_info = INFO
     def read_sensor_data(self):
+        self.print_reading(READING)
         return dict(READING)
 
 @pytest.fixture
@@ -42,6 +43,9 @@ def mock_paho_client():
     with patch('paho.mqtt.client.Client', autospec=True) as mock_client:
         yield mock_client
 
+
+# BaseSensor tests
+
 def test_abstract_method():
     # this should fail if read_sensor_data is not implemented
     class BrokenSensorSubclass(BaseSensor):
@@ -57,6 +61,9 @@ def test_name_type():
     with MySensor(name='HAL 9000') as sensor:
         assert sensor.sensor_type == 'TestSensor'
         assert sensor.sensor_name == 'HAL 9000'
+
+def test_log_path(sensor):
+    assert str(sensor.log_path).endswith('/sam_testhost_TestSensor.jsonl')
 
 def test_iter_readings(sensor):
     # check that iter_readings() yields values returned by read_sensor_data()
@@ -99,6 +106,41 @@ def test_reading_num(sensor):
     readings = list(sensor.iter_readings(delay=0, n=5))
     assert sensor.reading_num == 10
 
+def test_log(sensor, tmp_path):
+    payload = '{"foo": 1}'
+    sensor.log_path = tmp_path / "testlog.jsonl"
+    sensor.log(payload)
+    with open(sensor.log_path) as f:
+        lines = f.readlines()
+    assert lines[-1].strip() == payload
+    # test for nonexisting file
+    sensor.log_path = "/nonexistent/path/testlog.jsonl"
+    # Patch sensor.print to check error message
+    from unittest.mock import patch
+    with patch.object(sensor, 'print') as mock_print:
+        sensor.log(payload)
+        mock_print.assert_called_once()
+        assert '/nonexistent/path/testlog.jsonl' in str(mock_print.call_args[0][0])
+
+def test_print_reading(sensor, monkeypatch):
+    from simoc_sam import config
+    with patch.object(sensor, 'log') as mock_log, \
+         patch.object(sensor, 'print') as mock_print:
+        # test that both print and log are called once
+        sensor.print_reading(READING)
+        mock_print.assert_called_once()
+        mock_log.assert_called_once()
+        mock_log.assert_called_with(json.dumps(READING))
+        # reset mocks
+        mock_print.reset_mock()
+        mock_log.reset_mock()
+        # disable logging and test that only print is called
+        monkeypatch.setattr(config, "enable_jsonl_logging", False)
+        sensor.print_reading(READING)
+        mock_log.assert_not_called()
+        mock_print.assert_called_once()
+
+
 # MQTTWrapper tests
 
 def test_mqttwrapper_init(sensor):
@@ -108,7 +150,6 @@ def test_mqttwrapper_init(sensor):
     assert wrapper.read_delay == 10
     assert wrapper.verbose is True
     assert wrapper.topic == f'sam/testhost/{sensor.sensor_name}'
-    assert str(wrapper.log_fname).endswith(f'sam_testhost_{sensor.sensor_name}.jsonl')
 
 def test_mqttwrapper_connect_start_stop(wrapper):
     mqttc = wrapper.mqttc
@@ -131,32 +172,15 @@ def test_mqttwrapper_on_connect_and_disconnect(wrapper, mock_print):
 
 def test_mqttwrapper_send_data(wrapper, mock_print):
     mqttc = wrapper.mqttc
-    wrapper.log = Mock()
     wrapper.send_data(n=2)
     assert mqttc.publish.call_count == 2
     for call in mqttc.publish.call_args_list:
         assert call.kwargs['payload'] is not None
         assert call.args[0] == wrapper.topic
-    assert wrapper.log.call_count == 2
     assert mock_print.call_count >= 2
 
 def test_mqttwrapper_send_data_publish_error(wrapper, mock_print):
     mqttc = wrapper.mqttc
-    wrapper.log = Mock()
     mqttc.publish.side_effect = RuntimeError("fail")
     wrapper.send_data(n=1)
     mock_print.assert_any_call('No longer connected to the server (fail)...')
-
-def test_mqttwrapper_log_success_and_failure(wrapper, tmp_path, mock_print):
-    payload = '{"foo": 1}'
-    wrapper.log_fname = str(tmp_path / "testlog.jsonl")
-    wrapper.log(payload)
-    with open(wrapper.log_fname) as f:
-        lines = f.readlines()
-    assert lines[-1].strip() == payload
-    # test for nonexisting file
-    wrapper.log_fname = "/nonexistent/path/testlog.jsonl"
-    wrapper.log(payload)
-    assert mock_print.call_count == 1
-    assert '/nonexistent/path/testlog.jsonl' in str(mock_print.call_args[0][0])
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,10 @@ from simoc_sam import defaults
 
 def test_default_vars():
     vars = [
-        'mqtt_host', 'mqtt_port', 'sio_host', 'sio_port', 'simoc_web_port',
-        'mqtt_topic_location', 'log_dir', 'simoc_web_dist_dir', 'sensor_read_delay',
-        'mqtt_reconnect_delay', 'verbose_sensor', 'verbose_mqtt',
-        'enable_jsonl_logging', 'humans', 'volume',
+        'location', 'humans', 'volume', 'sensors', 'sensor_read_delay',
+        'mqtt_host', 'mqtt_port', 'mqtt_reconnect_delay', 'sio_host', 'sio_port',
+        'mqtt_topic_sub', 'simoc_web_port', 'simoc_web_dist_dir',
+        'verbose_sensor', 'verbose_mqtt', 'enable_jsonl_logging', 'log_dir',
     ]
     for var in vars:
         assert hasattr(config, var)


### PR DESCRIPTION
This PR moves the jsonl logging from the `MQTTWrapper` to the `BaseSensor` class.

Fixes #221.