### PR TITLE
Preserve HOME envvar while running as sudo

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -67,7 +67,8 @@ def needs_root(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
         if os.geteuid() != 0:
-            os.execvp('sudo', ['sudo', sys.executable, *sys.argv])
+            os.execvp('sudo', ['sudo', '--preserve-env=HOME',
+                               sys.executable, *sys.argv])
             return
         else:
             return func(*args, **kwargs)


### PR DESCRIPTION
The `HOME` env var is used by `Path.home()` to find files such as the user config introduced in #214.  Some `simoc-sam.py` commands are decorated with `@needs_root`, that run the command with `sudo`.  Running commands with `sudo` changes the current user, which changes the value of `HOME` and affects the result of `Path.home()`.  This PR fixes `@needs_root` to preserve the original `HOME`.