### PR TITLE
Ensure `simoc-sam.py` run without `simoc_sam` installed

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -18,7 +18,11 @@ except ModuleNotFoundError:
     # keep running if jinja2 is missing
     Template = None
 
-from simoc_sam import config
+try:
+    from simoc_sam import config
+except ModuleNotFoundError:
+    # keep running if simoc_sam is not installed yet
+    config = None
 
 
 HOME = pathlib.Path.home()


### PR DESCRIPTION
#214 introduced a new config file that is imported and used by `simoc-sam.py`.  The import only works if the `simoc_sam` package has been installed (which happens after the `create-venv` command), meaning that running `simoc-sam.py` before the venv is created and the package installed fails.

This PR ensures that `simoc-sam.py` runs properly even in that case.