### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Install and test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/overthesun/simoc-sam/security/code-scanning/1](https://github.com/overthesun/simoc-sam/security/code-scanning/1)

To fix the issue, you should add an explicit `permissions` block to the workflow. Because the workflow only checks out code and runs local tests, it only needs read access to repository contents. The best place to define the permission is directly under the root level of the workflow, making it apply to all jobs unless specifically overridden. Add the following block after the `name` field (line 4 or 5):

```yaml
permissions:
  contents: read
```

No imports or other changes are necessary outside of the YAML workflow file. No additional dependencies or steps need to be defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
