### PR TITLE
Add certs support to `MQTTWrapper` for secure MQTT connections

### DIFF
--- a/src/simoc_sam/config.py
+++ b/src/simoc_sam/config.py
@@ -39,3 +39,7 @@ if location is None:
     hostname = socket.gethostname()
     # Remove trailing digits from the hostname to get the location
     location = hostname.rstrip('0123456789')
+
+if mqtt_secure and not mqtt_certs_dir.exists():
+    print(f"Warning: MQTT secure is enabled but the certs dir "
+          f"<{mqtt_certs_dir}> does not exist.")

--- a/src/simoc_sam/defaults.py
+++ b/src/simoc_sam/defaults.py
@@ -21,6 +21,8 @@ sensor_read_delay = 10.0
 # MQTT configuration
 mqtt_host = 'localhost'
 mqtt_port = 1883
+mqtt_secure = False
+mqtt_certs_dir = Path.home() / '.mqttcerts'
 mqtt_reconnect_delay = 5.0
 
 

--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -132,13 +132,20 @@ class BaseSensor(ABC):
 
 class MQTTWrapper:
     def __init__(self, sensor, *, read_delay=config.sensor_read_delay,
-                 verbose=config.verbose_sensor, location=config.location):
+                 verbose=config.verbose_sensor, location=config.location,
+                 secure=config.mqtt_secure, certs_dir=config.mqtt_certs_dir):
         self.sensor = sensor
         self.read_delay = read_delay  # how long to wait between readings
         self.verbose = verbose  # toggle verbose output
         # aiomqtt still requires paho-mqtt 1.6
         # self.mqttc = mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
         self.mqttc = mqttc = mqtt.Client()
+        if secure:
+            self.print("Using secure MQTT connection")
+            self.mqttc.tls_set(ca_certs=str(certs_dir / 'ca.crt'),
+                               certfile=str(certs_dir / 'client.crt'),
+                               keyfile=str(certs_dir / 'client.key'))
+            self.mqttc.tls_insecure_set(True)  # allow self-signed certs
         mqttc.on_connect = self.on_connect
         mqttc.on_disconnect = self.on_disconnect
         hostname = socket.gethostname()

--- a/tests/test_basesensor.py
+++ b/tests/test_basesensor.py
@@ -147,10 +147,17 @@ def test_iter_readings_logs(sensor, monkeypatch):
 # MQTTWrapper tests
 
 def test_mqttwrapper_init(sensor):
-    # test with custom args
-    wrapper = basesensor.MQTTWrapper(sensor, read_delay=10, verbose=True)
+    """Test that MQTTWrapper uses config defaults correctly."""
+    wrapper = basesensor.MQTTWrapper(sensor)
     assert wrapper.sensor is sensor
-    assert wrapper.read_delay == 10
+    assert wrapper.read_delay == config.sensor_read_delay
+    assert wrapper.verbose == config.verbose_sensor
+    assert wrapper.topic.startswith(config.location)
+    assert wrapper.topic == f'testhost/testhost1/{sensor.sensor_name}'
+    # test with custom args
+    wrapper = basesensor.MQTTWrapper(sensor, read_delay=5, verbose=True)
+    assert wrapper.sensor is sensor
+    assert wrapper.read_delay == 5
     assert wrapper.verbose is True
     assert wrapper.topic == f'testhost/testhost1/{sensor.sensor_name}'
 
@@ -187,3 +194,21 @@ def test_mqttwrapper_send_data_publish_error(wrapper, mock_print):
     mqttc.publish.side_effect = RuntimeError("fail")
     wrapper.send_data(n=1)
     mock_print.assert_any_call('No longer connected to the server (fail)...')
+
+def test_mqttwrapper_insecure_init(sensor):
+    """Test MQTTWrapper initialization with secure=False (default)."""
+    wrapper = basesensor.MQTTWrapper(sensor, secure=False)
+    wrapper.mqttc.tls_set.assert_not_called()
+    wrapper.mqttc.tls_insecure_set.assert_not_called()
+
+def test_mqttwrapper_secure_init(sensor):
+    """Test MQTTWrapper initialization with secure=True."""
+    from pathlib import Path
+    certs_dir = Path('/test/certs')
+    wrapper = basesensor.MQTTWrapper(sensor, secure=True, certs_dir=certs_dir)
+    wrapper.mqttc.tls_set.assert_called_once_with(
+        ca_certs='/test/certs/ca.crt',
+        certfile='/test/certs/client.crt',
+        keyfile='/test/certs/client.key'
+    )
+    wrapper.mqttc.tls_insecure_set.assert_called_once_with(True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,9 +6,9 @@ from simoc_sam import defaults
 
 def test_default_vars():
     vars = [
-        'humans', 'volume', 'sensors', 'sensor_read_delay',
-        'mqtt_host', 'mqtt_port', 'mqtt_reconnect_delay', 'sio_host', 'sio_port',
-        'mqtt_topic_sub', 'simoc_web_port', 'simoc_web_dist_dir',
+        'humans', 'volume', 'sensors', 'sensor_read_delay', 'mqtt_host',
+        'mqtt_port', 'mqtt_secure', 'mqtt_certs_dir', 'mqtt_reconnect_delay',
+        'sio_host', 'sio_port', 'mqtt_topic_sub', 'simoc_web_port', 'simoc_web_dist_dir',
         'verbose_sensor', 'verbose_mqtt', 'enable_jsonl_logging', 'log_dir',
     ]
     for var in vars:


### PR DESCRIPTION
This PR:
* adds two config options: `mqtt_secure` and `mqtt_certs_dir`
* when `mqtt_secure` is true, it will look in `mqtt_certs_dir` for the certs and use them for the MQTT connection