### PR TITLE
Ensure that config dirs are Path objects

### DIFF
--- a/src/simoc_sam/config.py
+++ b/src/simoc_sam/config.py
@@ -34,12 +34,25 @@ def load_user_config(config_path):
 user_config_path = Path.home() / ".config/simoc-sam/config.py"
 load_user_config(user_config_path)
 
+
+# validate and update config vars
+
+# ensure path variables are Path objects
+for var in ['mqtt_certs_dir', 'simoc_web_dist_dir', 'log_dir']:
+    if var not in globals():
+        continue
+    v = globals()[var]
+    if not isinstance(v, Path):
+        globals()[var] = Path(v)
+
+# set location from hostname if not set
 if location is None:
     import socket
     hostname = socket.gethostname()
     # Remove trailing digits from the hostname to get the location
     location = hostname.rstrip('0123456789')
 
+# warn if mqtt_secure is True but the certs dir does not exist
 if mqtt_secure and not mqtt_certs_dir.exists():
     print(f"Warning: MQTT secure is enabled but the certs dir "
           f"<{mqtt_certs_dir}> does not exist.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,14 +57,13 @@ def test_user_config_override(user_config, monkeypatch):
 def test_path_variables_user_override(user_config):
     """Test that string paths are converted to Path objects."""
     # create user config that sets path vars with strings
-    user_config.write_text('mqtt_certs_dir = "/custom/certs"\n'
-                           'simoc_web_dist_dir = "/custom/dist"\n'
-                           'log_dir = "/custom/logs"\n')
+    vars = ['mqtt_certs_dir', 'simoc_web_dist_dir', 'log_dir']
+    paths = ['/custom/certs', '/custom/dist', '/custom/logs']
+    config_text = '\n'.join(f'{var} = {path!r}' for var, path in zip(vars, paths))
+    user_config.write_text(config_text)
     importlib.reload(config)
     # verify they are converted to Path objects
-    path_vars = ['mqtt_certs_dir', 'simoc_web_dist_dir', 'log_dir']
-    expected_values = ['/custom/certs', '/custom/dist', '/custom/logs']
-    for var, expected in zip(path_vars, expected_values):
+    for var, path in zip(vars, paths):
         value = getattr(config, var)
         assert isinstance(value, Path)
-        assert str(value) == expected
+        assert str(value) == path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,21 @@
 import importlib
+from pathlib import Path
+
+import pytest
 
 from simoc_sam import config
 from simoc_sam import defaults
+
+
+@pytest.fixture
+def user_config(tmp_path, monkeypatch):
+    """Fixture that sets up user config directory and monkeypatches HOME."""
+    user_config_dir = tmp_path / '.config' / 'simoc-sam'
+    user_config_dir.mkdir(parents=True)
+    user_config_path = user_config_dir / 'config.py'
+    # set the home to tmp_path so that Path().home() points to tmp_path
+    monkeypatch.setenv('HOME', str(tmp_path))
+    return user_config_path
 
 
 def test_default_vars():
@@ -20,18 +34,13 @@ def test_default_vars():
     assert config.location == 'testhost'
 
 
-def test_user_config_override(tmp_path, monkeypatch):
+def test_user_config_override(user_config, monkeypatch):
     from simoc_sam import defaults
     assert config.mqtt_host is defaults.mqtt_host
     assert config.location == 'testhost'
     # create an user config that overrides the mqtt_host
-    user_config_dir = tmp_path / '.config' / 'simoc-sam'
-    user_config_dir.mkdir(parents=True)
-    user_config_path = user_config_dir / 'config.py'
-    user_config_path.write_text('mqtt_host = "overridden_host"\n'
-                                'location = "custom_location"\n')
-    # Monkeypatch $HOME to tmp_path to test user config loading
-    monkeypatch.setenv('HOME', str(tmp_path))
+    user_config.write_text('mqtt_host = "overridden_host"\n'
+                           'location = "custom_location"\n')
     importlib.reload(config)
     assert config.mqtt_host == "overridden_host"
     assert config.location == "custom_location"
@@ -41,5 +50,21 @@ def test_user_config_override(tmp_path, monkeypatch):
     assert config.mqtt_host is defaults.mqtt_host
     assert config.location == 'testhost'
     # test load_user_config directly
-    config.load_user_config(user_config_path)
+    config.load_user_config(user_config)
     assert config.mqtt_host == "overridden_host"
+
+
+def test_path_variables_user_override(user_config):
+    """Test that string paths are converted to Path objects."""
+    # create user config that sets path vars with strings
+    user_config.write_text('mqtt_certs_dir = "/custom/certs"\n'
+                           'simoc_web_dist_dir = "/custom/dist"\n'
+                           'log_dir = "/custom/logs"\n')
+    importlib.reload(config)
+    # verify they are converted to Path objects
+    path_vars = ['mqtt_certs_dir', 'simoc_web_dist_dir', 'log_dir']
+    expected_values = ['/custom/certs', '/custom/dist', '/custom/logs']
+    for var, expected in zip(path_vars, expected_values):
+        value = getattr(config, var)
+        assert isinstance(value, Path)
+        assert str(value) == expected


### PR DESCRIPTION
This PR updates `config.py` to check that dirs are always converted to `Path` objects, even if the user entered strings in the user `config.py`.