### PR TITLE
Add logs as data source option for the siobridge

### DIFF
--- a/src/simoc_sam/config.py
+++ b/src/simoc_sam/config.py
@@ -57,3 +57,6 @@ if location is None:
 if mqtt_secure and not mqtt_certs_dir.exists():
     print(f"Warning: MQTT secure is enabled but the certs dir "
           f"<{mqtt_certs_dir}> does not exist.")
+
+if not enable_jsonl_logging and data_source == 'logs':
+    print("Warning: JSONL logging is disabled but data_source is 'logs'. ")

--- a/src/simoc_sam/defaults.py
+++ b/src/simoc_sam/defaults.py
@@ -29,6 +29,7 @@ mqtt_reconnect_delay = 5.0
 # SIMOC Web / SIO bridge configuration
 sio_host = 'localhost'
 sio_port = 8081
+data_source = 'logs'  # 'mqtt' or 'logs'
 mqtt_topic_sub = f'{location}/#'
 simoc_web_port = 8080  # used for CORS validation
 simoc_web_dist_dir = Path.home() / 'dist'

--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -14,6 +14,10 @@ def random_id(length=6):
     """Return a random hexadecimal string of specified length"""
     return ''.join(random.choice('0123456789ABCDEF') for i in range(length))
 
+def get_log_path(sensor_name):
+    hostname = socket.gethostname()
+    fname = f'{config.location}_{hostname}_{sensor_name}.jsonl'
+    return config.log_dir / fname
 
 class BaseSensor(ABC):
     """The base class Sensors should inherit from."""
@@ -39,9 +43,7 @@ class BaseSensor(ABC):
         self.verbose = verbose
         # the total number of values read through iter_readings
         self.reading_num = 0
-        hostname = socket.gethostname()
-        fname = f'{config.location}_{hostname}_{self.sensor_name}.jsonl'
-        self.log_path = config.log_dir / fname
+        self.log_path = get_log_path(self.sensor_name)
         if config.enable_jsonl_logging:
             config.log_dir.mkdir(exist_ok=True)  # ensure the log dir exists
 

--- a/src/simoc_sam/siobridge.py
+++ b/src/simoc_sam/siobridge.py
@@ -5,6 +5,7 @@ import asyncio
 import ipaddress
 import traceback
 
+from pathlib import Path
 from datetime import datetime
 from collections import defaultdict, deque
 
@@ -15,6 +16,7 @@ import netifaces
 from aiohttp import web
 
 from .sensors import utils
+from .sensors.basesensor import get_log_path
 from . import config
 
 
@@ -194,6 +196,72 @@ async def mqtt_handler():
             await asyncio.sleep(interval)
 
 
+async def read_jsonl_file(file_path):
+    """Async generator that waits for new lines appended to JSONL file (like tail -f)."""
+    try:
+        # If file doesn't exist, wait for it to be created
+        while not file_path.exists():
+            print(f'Waiting for log file to be created: {file_path}')
+            await asyncio.sleep(1)
+        print(f'Starting to monitor log file for new lines: {file_path}')
+        with open(file_path) as f:
+            # seek to end of file and monitor for new lines
+            f.seek(0, 2)
+            while True:
+                line = f.readline()
+                if line.strip():
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError as e:
+                        print(f'Error parsing JSON from {file_path}: {e}')
+                        continue
+                else:
+                    # No new line, wait a bit before checking again
+                    await asyncio.sleep(1)
+    except Exception as e:
+        print(f'Error reading log file {file_path}: {e}')
+
+
+async def process_sensor_log(sensor, log_file):
+    """Process a single sensor's log file continuously."""
+    sensor_id = f'file.{sensor}'
+    # Ensure sensor info is available
+    if sensor_id not in SENSOR_INFO:
+        SENSORS.add(sensor_id)
+        info = copy.deepcopy(SENSOR_DATA[sensor])
+        info['sensor_name'] = sensor_id
+        info['sensor_id'] = sensor_id
+        info['sensor_desc'] = f'{sensor} sensor from log file {log_file.name}'
+        SENSOR_INFO[sensor_id] = info
+        await emit_to_subscribers('sensor-info', SENSOR_INFO)
+    print(f'Starting to process log file for {sensor}: {log_file}')
+    # Read and process each line from the log file continuously
+    try:
+        async for reading in read_jsonl_file(log_file):
+            # Add the reading to SENSOR_READINGS
+            SENSOR_READINGS[sensor_id].append(reading)
+    except Exception as e:
+        print(f'Error processing log file for {sensor}: {e}')
+
+
+async def log_handler():
+    """Handle log files from config.log_dir and populate SENSOR_READINGS."""
+    log_dir = Path(config.log_dir)
+    sensors = config.sensors
+    if not log_dir.exists():
+        print(f'Log directory does not exist: {log_dir}')
+        return
+    print(f'Starting log handler for directory: {log_dir}')
+    print(f'Looking for sensors: {sensors}')
+    tasks = []
+    for sensor in sensors:
+        log_file = get_log_path(sensor)
+        print(f'Log file for {sensor}: {log_file}')
+        task = asyncio.create_task(process_sensor_log(sensor, log_file))
+        tasks.append(task)
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 # app setup
 
 async def index(request):
@@ -208,10 +276,15 @@ def create_app():
     return app
 
 async def init_app(app):
-    # Start the MQTT handler in the background
+    # Start handlers based on configuration
     sio.attach(app)
     sio.start_background_task(emit_readings)
-    asyncio.ensure_future(mqtt_handler())
+    if config.data_source == 'mqtt':
+        print('Starting MQTT handler for sensor data')
+        asyncio.ensure_future(mqtt_handler())
+    else:
+        print('Starting log handler for sensor data')
+        asyncio.ensure_future(log_handler())
     return app
 
 


### PR DESCRIPTION
This PR adds support in `siobridge.py` for reading data from the `jsonl` logs files instead of MQTT.