### PR TITLE
Use config dist dir for index location

### DIFF
--- a/src/simoc_sam/siobridge.py
+++ b/src/simoc_sam/siobridge.py
@@ -198,7 +198,7 @@ async def mqtt_handler():
 
 async def index(request):
     """Serve the client-side application."""
-    with open('index.html') as f:
+    with open(config.simoc_web_dist_dir / 'index.html') as f:
         return web.Response(text=f.read(), content_type='text/html')
 
 def create_app():


### PR DESCRIPTION
The siobridge should use the dist dir location configured in the `config.py`. 