### PR TITLE
Add `hostname.local` to CORS `allowed_origins`

### DIFF
--- a/src/simoc_sam/siobridge.py
+++ b/src/simoc_sam/siobridge.py
@@ -47,7 +47,8 @@ SUBSCRIBERS = set()
 def get_host_ips():
     """Return a list of IPs and hostnames for the current host."""
     hostname = socket.gethostname()
-    ips = {hostname, 'localhost', '127.0.0.1'}  # init with known IPs/hostnames
+    # init with known IPs/hostnames
+    ips = {hostname, f'{hostname}.local', 'localhost', '127.0.0.1'}
     # find all local private networks we are in and our IP in those networks
     for interface in netifaces.interfaces():
         addrs = netifaces.ifaddresses(interface).get(netifaces.AF_INET, [])


### PR DESCRIPTION
This is needed when accessing SIMOC Live from the same LAN through the `http://hostname.local` URL.