### PR TITLE
Fix `test_config` path checks

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,13 @@ def test_default_vars():
     for var in vars:
         assert hasattr(config, var)
         assert hasattr(defaults, var)
-        assert getattr(config, var) is getattr(defaults, var)
+        if var not in config._path_vars:
+            assert getattr(config, var) is getattr(defaults, var)
+        else:
+            # paths are either str or Path in defaults, but always Path in config
+            assert isinstance(getattr(defaults, var), (str, Path))
+            assert isinstance(getattr(config, var), Path)
+            assert str(getattr(config, var)) == str(getattr(defaults, var))
     # location is set from hostname when None
     assert defaults.location is None
     assert config.location == 'testhost'


### PR DESCRIPTION
`config.py` automatically converts all paths defined in `defaults.py` into `pathlib.Path` objects.  The test in `test_config.py` verified that the values defined in `defaults.py` are identical to the ones in `config.py`, but this fails after the conversion to `pathlib.Path`.

This PR fixes the check and verifies that `defaults.py` accepts both `str` and `Path`, and that all paths become equivalent `Path` instances in `config.py`.