### PR TITLE
Ensure the wifi is on while setting up nm connections

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -260,6 +260,7 @@ def setup_nmconn(nmconn_file, repls):
     os.chown(nmconn_file, 0, 0)  # owner is now root
     if not run(['systemctl', 'is-enabled', 'NetworkManager']):
         run(['systemctl', 'enable', 'NetworkManager'])
+    run(['nmcli', 'radio', 'wifi', 'on'])  # ensure wifi is on
     run(['systemctl', 'restart', 'NetworkManager'])
 
 def teardown_nmconn(nmconn_file):


### PR DESCRIPTION
The `setup-hotspot` command failed to work on a Raspberry Zero 2 W with Raspberry OS Bookworm.  Apparently this is because wiFi was disabled in NetworkManager.  This is taken from a newly burned Bookworm-based Raspberry OS image, created with the Raspberry Imager 2.0.3 without configuring WiFi (connected via ethernet through an adapter):
```console
$ nmcli --version
nmcli tool, version 1.42.4
$ nmcli general status
STATE      CONNECTIVITY  WIFI-HW  WIFI      WWAN-HW  WWAN    
connected  full          enabled  disabled  missing  enabled 
$ nmcli radio all
WIFI-HW  WIFI      WWAN-HW  WWAN    
enabled  disabled  missing  enabled 
$ nmcli dev status
DEVICE  TYPE      STATE                   CONNECTION         
eth0    ethernet  connected               Wired connection 1 
lo      loopback  connected (externally)  lo                 
wlan0   wifi      unavailable             --  
$ rfkill list
0: hci0: Bluetooth
        Soft blocked: no
        Hard blocked: no
1: phy0: Wireless LAN
        Soft blocked: yes
        Hard blocked: no
```

Enabling it explicitly seems enough to fix the issue:

```console
$ sudo nmcli radio wifi on
$ nmcli radio all
WIFI-HW  WIFI     WWAN-HW  WWAN    
enabled  enabled  missing  enabled 
$ nmcli dev status
DEVICE         TYPE      STATE                   CONNECTION         
wlan0          wifi      connected               hotspot            
eth0           ethernet  connected               Wired connection 1 
lo             loopback  connected (externally)  lo                 
p2p-dev-wlan0  wifi-p2p  disconnected    
```

Running this command while the wifi is already enabled is a no-op, so I added it to `setup_nmconn`.