### PR TITLE
Automatically enable i2c in `initial-setup`

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -511,7 +511,6 @@ def raspi_config(cmd, *args):
     return subprocess.run(['sudo', 'raspi-config', 'nonint', cmd, *args])
 
 @cmd
-@needs_root
 def enable_i2c():
     """Enable i2c using raspi-config."""
     print('Enabling i2c...')


### PR DESCRIPTION
This PR fixes #290 by adding an `enable-i2c` command and running it during the initial setup.