### PR TITLE
Remove `chromium` during the `initial-setup`

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -42,7 +42,7 @@ HOSTNAME = socket.gethostname()
 
 APT_INSTALL = ['nmap', 'vim', 'tcpdump', 'tmux', 'nginx',
                'mosquitto-clients', 'avahi-utils']
-APT_REMOVE = []
+APT_REMOVE = ['chromium']
 
 COMMANDS = {}
 


### PR DESCRIPTION
During the `apt upgrade` on RPi OS Trixie I got a message about a conflict related to the `chromium` package.  Since we don't need it and it saves ~450MB of space, it's easy to remove it.

This PR refactors the `apt` packages management to add a list of packages to be remove, which includes `chromium`.  Fixes #313.