### PR TITLE
Check if a service will actually start on boot

### DIFF
--- a/hostinfo.py
+++ b/hostinfo.py
@@ -99,7 +99,7 @@ def check_journal_errors(service_name, n_lines=15):
     """Check for errors in the journal output of the given service."""
     try:
         cmd = ['journalctl', '-u', service_name, '-n', str(n_lines), '--no-pager']
-        result = subprocess.run(cmd , capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
     except Exception as e:
         print(f"Error checking journal for {service_name!r}: {e}")
         return True


### PR DESCRIPTION
Fixes #223 by checking if a service is listed in `/etc/systemd/system/multi-user.target.wants/` or `/etc/systemd/system/graphical.target.wants/`.
If the service is not listed there, it might still be enabled but it won't start at boot.