### PR TITLE
Move `StartLimitIntervalSec` in the `[Unit]` section

### DIFF
--- a/configs/display-runner@.service
+++ b/configs/display-runner@.service
@@ -8,6 +8,7 @@
 
 [Unit]
 Description=%i display runner service
+StartLimitIntervalSec=0
 After=network.target
 
 [Service]
@@ -17,7 +18,6 @@ Environment=PYTHONUNBUFFERED=1
 ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.displays.%i
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
 StandardOutput=journal
 StandardError=journal
 

--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -10,6 +10,7 @@
 
 [Unit]
 Description=%i sensor runner service
+StartLimitIntervalSec=0
 After=network.target
 
 [Service]
@@ -19,7 +20,6 @@ Environment=PYTHONUNBUFFERED=1
 ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.sensors.%i -v --mqtt
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
 StandardOutput=journal
 StandardError=journal
 

--- a/configs/siobridge.service
+++ b/configs/siobridge.service
@@ -10,6 +10,7 @@
 # see the script output.
 [Unit]
 Description=siobridge service to forward data to SIMOC web
+StartLimitIntervalSec=0
 After=network.target
 
 [Service]
@@ -19,7 +20,6 @@ Environment=PYTHONUNBUFFERED=1
 ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.siobridge
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=0
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
In recent versions of systemd (including the one we are using), `StartLimitIntervalSec` should be specified in the `[Unit]` section (not in `[Service]`).  This PR fixes this issue and the following warning:
```
Unknown key 'StartLimitIntervalSec' in section [Service], ignoring.
```