### PR TITLE
List the status of all required services in `print_services`

### DIFF
--- a/hostinfo.py
+++ b/hostinfo.py
@@ -111,7 +111,7 @@ def get_services_info(services=None):
     """Get info about the given systemd services using systemctl show."""
     if services:
         # if service is a template use a wildcard to get all instances
-        services = [service.replace('@', '@*') for service in services]
+        services = [re.sub(r'@(?=\.)|@$', '@*', service) for service in services]
     else:
         services = ['*.service']  # get all services if services is empty
     try:


### PR DESCRIPTION
This PR improves the `print_services` and `get_services_info` functions in a few ways:
* Icons have been improved to better reflect the service status (e.g. `activating` is now :yellow_circle: instead of :red_circle:);
* Before the table only include running services, now it should include all of them;
* Before the `get_all_running_services` was retrieving info for all running services, including the ones we didn't care about, and was not retrieving info about non-running services we cared about; now it only retrieves info about all services we care about;