### PR TITLE
Add commands to set up the PCF8523 as an hardware clock

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -616,7 +616,8 @@ def set_rtc_time(timestamp=None):
     if dt is None:
         return False
     formatted = dt.strftime("%Y-%m-%d %H:%M:%S")
-    return run(['sudo', 'hwclock', '--set', '--date', formatted])
+    return (run(['sudo', 'hwclock', '--set', '--date', formatted]) and
+            run(['timedatectl', 'status']))
 
 @cmd
 @needs_root


### PR DESCRIPTION
This PR is an alternative implementation of #320 that installs the PCF8523 as an hardware clock directly, without using Adafruit libraries to read/set the RTC clock.  Fixes #322.