### PR TITLE
Add the `push-update` command to push updates directly to the RPi

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -196,12 +196,16 @@ def push_update(target=None):
     else:
         # use default RPi hotspot IP (NetworkManager 'shared' mode)
         user, host, path = 'pi', '10.42.0.1', '/home/pi/simoc-sam'
-        print(f'Using default RPi hotspot IP: {host}')
     # push the branch to the RPi
     git_url = f'{user}@{host}:{path}'
     print(f'Pushing branch {branch!r} to {git_url}...')
     cmd = ['git', 'push', git_url, branch]
-    return run(cmd, cwd=SIMOC_SAM_DIR)
+    success = run(cmd, cwd=SIMOC_SAM_DIR)
+    if success:
+        print(f'Remote branch {branch!r} successfully updated.')
+    else:
+        print(f'Failed to push updates: see error log above for details.')
+    return success
 
 
 @cmd


### PR DESCRIPTION
This PR allows users to push updates from their PC directly to the RPi (running in hotspot mode) they are connected to.

The PR adds 3 new `simoc-sam` commands:
* `push-update`: that pushes updates directly to the RPi;
* `setup-git-remote-push`: which allows the RPi to receive pushes;
* `teardown-git-remote-push`: which disallows remote pushes;

For this to work:
* the RPi must be configured to run in hotspot mode with `setup-hotspot`;
* the RPi must be configured to accept pushes with `setup-git-remote-push`;
* the user must be connected directly to the RPi with their PC;
* the user has to clone the repo on their PC and run `python simoc-sam.py push-update`;
* the checked-out branch on the user PC must match the one on the RPi;
* the RPi cannot have uncommitted changes;