### PR TITLE
Use `config.sensor_read_delay` as default delay in `siobridge`

### DIFF
--- a/src/simoc_sam/siobridge.py
+++ b/src/simoc_sam/siobridge.py
@@ -131,7 +131,6 @@ async def emit_to_subscribers(*args, **kwargs):
 
 async def emit_readings():
     """Emit a bundle with the latest reading of all sensors."""
-    args = sensor_utils.parse_args()  # TODO: create separate parser for the server
     delay = config.sensor_read_delay  # emit at the same rate data is read
     print(f'Broadcasting data every {delay} seconds.')
     n = 0


### PR DESCRIPTION
Currently the `siobridge` is sending data every second, even if the data is read from the sensors at a different rate.  If the `config.sensor_read_delay` is e.g. 10 seconds, the `siobridge` sends the same reading 10 times, creating 10 equal points in the graph.

This PR uses `config.sensor_read_delay` as delay in `siobridge` too, so that the rate at which the values are displayed in the frontend matches the rate at which data is read from the sensors.