### PR TITLE
Automatically enable remote pushes in `setup_hotspot`

### DIFF
--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -314,8 +314,9 @@ def setup_nmconn(nmconn_file, repls):
     if not run(['systemctl', 'is-enabled', 'NetworkManager']):
         run(['systemctl', 'enable', 'NetworkManager'])
     # ensure wifi is on and reload connections (will auto-activate interface)
-    return (run(['nmcli', 'radio', 'wifi', 'on']) and
-            run(['nmcli', 'connection', 'reload']))
+    wifi_enabled = run(['nmcli', 'radio', 'wifi', 'on'])
+    conn_reloaded = run(['nmcli', 'connection', 'reload'])
+    return wifi_enabled and conn_reloaded
 
 def teardown_nmconn(conn_id):
     """Stop and remove the given NetworkManager connection."""


### PR DESCRIPTION
This PR automatically enables push updates (introduced in #336) when the hotspot is enabled with `sam setup-hotspot`, and disables them when it's disabled with `sam teardown-hotspot`.