### PR TITLE
Simplify config by using `str` paths

### DIFF
--- a/src/simoc_sam/config.py
+++ b/src/simoc_sam/config.py
@@ -44,7 +44,7 @@ for var in _path_vars:
         continue
     v = globals()[var]
     if not isinstance(v, Path):
-        globals()[var] = Path(v)
+        globals()[var] = Path(v).expanduser()
 
 # set location from hostname if not set
 if location is None:

--- a/src/simoc_sam/defaults.py
+++ b/src/simoc_sam/defaults.py
@@ -4,8 +4,6 @@ This file is copied to ~/.config/simoc-sam/config.py for user overrides,
 with a symlink pointing to it for easier editing/discoverability.
 """
 
-from pathlib import Path
-
 
 # HAB info
 location = None
@@ -41,7 +39,7 @@ A-z: {bno085_linear_accel_z:.2f}
 mqtt_host = 'localhost'
 mqtt_port = 1883
 mqtt_secure = False
-mqtt_certs_dir = Path.home() / '.mqttcerts'
+mqtt_certs_dir = '~/.mqttcerts'
 mqtt_reconnect_delay = 5.0
 
 
@@ -57,4 +55,4 @@ simoc_web_dist_dir = '/var/www/simoc'
 verbose_sensor = False
 verbose_mqtt = False
 enable_jsonl_logging = True
-log_dir = Path.home() / 'logs'
+log_dir = '~/logs'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,10 +32,13 @@ def test_default_vars():
         if var not in config._path_vars:
             assert getattr(config, var) is getattr(defaults, var)
         else:
-            # paths are either str or Path in defaults, but always Path in config
-            assert isinstance(getattr(defaults, var), (str, Path))
-            assert isinstance(getattr(config, var), Path)
-            assert str(getattr(config, var)) == str(getattr(defaults, var))
+            default_path= getattr(defaults, var)
+            config_path = getattr(config, var)
+            assert isinstance(default_path, str)  # always a str
+            assert isinstance(config_path, Path)  # always converted to Path
+            assert config_path.is_absolute()
+            assert '~' not in str(config_path)  # should be expanded
+            assert str(config_path) == str(Path(default_path).expanduser())
     # location is set from hostname when None
     assert defaults.location is None
     assert config.location == 'testhost'


### PR DESCRIPTION
This PR simplifies the default config by removing the import and usage of `Path` and opting for plain `str` (possibly containing a `~`).  The `str` paths are then converted to actual `Path` objects automatically by `config.py`, and the `~` expanded to the home directory.