### PR TITLE
Increase `MAX_ROWS` in `ssd1306.py`

### DIFF
--- a/src/simoc_sam/displays/ssd1306.py
+++ b/src/simoc_sam/displays/ssd1306.py
@@ -18,7 +18,7 @@ from simoc_sam.displays import utils as display_utils
 SENSOR_READINGS = {}
 
 # number of rows for 128x64 rotated 90 degrees (including header)
-MAX_ROWS = 9
+MAX_ROWS = 10
 FONT = ImageFont.load_default()
 
 def draw_image(width, height, rows):


### PR DESCRIPTION
The empty space between the header and the reading is now counted as an empty row, so `MAX_ROWS` needs to be increased by `1`, or the last row of readings will be omitted.