### PR TITLE
Add driver for the ssd1327 grayscale OLED display

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ godirect==1.2.1
 rich==14.3.3
 pillow==11.3.0
 adafruit-circuitpython-ssd1306==2.12.22
+adafruit-circuitpython-ssd1327==1.4.9

--- a/src/simoc_sam/displays/displays.toml
+++ b/src/simoc_sam/displays/displays.toml
@@ -16,3 +16,11 @@ width = 128
 height = 64
 i2c_address = 0x3D
 reset_pin = "D4"
+
+[ssd1327]
+name = "SSD1327"
+description = "Grayscale 128x128 OLED display"
+module = "simoc_sam.displays.ssd1327"
+width = 128
+height = 128
+i2c_address = 0x3D

--- a/src/simoc_sam/displays/ssd1306.py
+++ b/src/simoc_sam/displays/ssd1306.py
@@ -8,7 +8,6 @@ board = sensor_utils.import_board()
 
 import digitalio
 import adafruit_ssd1306
-from PIL import Image, ImageDraw, ImageFont
 
 from simoc_sam import utils, config
 from simoc_sam.displays import utils as display_utils
@@ -19,24 +18,7 @@ SENSOR_READINGS = {}
 
 # number of rows for 128x64 rotated 90 degrees (including header)
 MAX_ROWS = 10
-FONT = ImageFont.load_default()
 
-def draw_image(width, height, rows):
-    """Draw sensor values on an image and return it."""
-    if not rows:
-        return  # nothing to display
-    image = Image.new("1", (width, height))
-    draw = ImageDraw.Draw(image)
-    # screen is rotated, so oled.width is actually the height
-    spacing = max(8, height // len(rows))  # calc row height dynamically
-    y = 0
-    for row in rows:
-        if not row.strip():
-            y += 6  # add extra spacing for blank lines
-        else:
-            draw.text((0, y), row, font=FONT, fill=255)
-            y += spacing
-    return image
 
 def show_image(oled, image):
     """Show the given image on the OLED display."""
@@ -57,7 +39,7 @@ async def update_display(oled):
         while True:
             rows = display_utils.format_values(SENSOR_READINGS, max_rows=MAX_ROWS)
             # swap height/width because the screen is rotated 90 degrees
-            image = draw_image(oled.height, oled.width, rows)
+            image = display_utils.draw_image(oled.height, oled.width, rows)
             if image:
                 show_image(oled, image)
             await asyncio.sleep(config.display_refresh)

--- a/src/simoc_sam/displays/ssd1327.py
+++ b/src/simoc_sam/displays/ssd1327.py
@@ -1,0 +1,87 @@
+"""Driver for the Adafruit SSD1327 OLED display (128x128 Grayscale)."""
+
+import time
+import asyncio
+
+import displayio
+import adafruit_ssd1327
+
+from i2cdisplaybus import I2CDisplayBus
+
+from simoc_sam import utils, config
+from simoc_sam.displays import utils as display_utils
+
+
+# store latest readings from each sensor (updated by MQTT handler)
+SENSOR_READINGS = {}
+
+# number of rows for 128x128 display (including header)
+MAX_ROWS = 15
+
+
+def blit_image_to_bitmap(bitmap, image, width):
+    """Write a 1-bit PIL image into the existing bitmap in-place.
+
+    Only writes pixels that differ from the bitmap's current state.
+    Returns the number of pixels changed.
+    """
+    pixels = image.getdata()
+    changes = 0
+    for i, pixel in enumerate(pixels):
+        val = 1 if pixel else 0
+        x = i % width
+        y = i // width
+        if bitmap[x, y] != val:
+            bitmap[x, y] = val
+            changes += 1
+    return changes
+
+
+async def update_display(display, bitmap, width, height):
+    """Continuously update the display with latest sensor values."""
+    prev_rows = None
+    while True:
+        t_start = time.time()
+        rows = display_utils.format_values(SENSOR_READINGS, max_rows=MAX_ROWS)
+        if rows != prev_rows:
+            image = display_utils.draw_image(width, height, rows)
+            if image:
+                blit_image_to_bitmap(bitmap, image, width)
+                display.refresh()
+            prev_rows = rows
+        # subtract full cycle time (writes + I2C refresh) from sleep
+        elapsed = time.time() - t_start
+        sleep_time = max(0, config.display_refresh - elapsed)
+        await asyncio.sleep(sleep_time)
+
+
+async def main():
+    """Main loop: read sensor values and display them on the OLED."""
+    display_config = display_utils.DISPLAY_DATA['ssd1327']
+    width, height = display_config.width, display_config.height
+    # initialize display
+    displayio.release_displays()
+    display_bus = I2CDisplayBus(
+        utils.get_i2c(),
+        device_address=display_config.i2c_address,
+    )
+    display = adafruit_ssd1327.SSD1327(display_bus, width=width, height=height)
+    # create a 2-color bitmap and a tile grid to hold it
+    bitmap = displayio.Bitmap(width, height, 2)
+    palette = displayio.Palette(2)
+    palette[0] = 0x000000  # black
+    palette[1] = 0xFFFFFF  # white
+    tile_grid = displayio.TileGrid(bitmap, pixel_shader=palette)
+    group = displayio.Group()
+    group.append(tile_grid)
+    display.root_group = group
+    display.auto_refresh = False
+    # start MQTT monitor and display update tasks
+    await asyncio.gather(
+        display_utils.mqtt_monitor(SENSOR_READINGS),
+        update_display(display, bitmap, width, height),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/simoc_sam/displays/utils.py
+++ b/src/simoc_sam/displays/utils.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 import tomli
 import aiomqtt
 
+from PIL import Image, ImageDraw, ImageFont
+
 from simoc_sam import utils
 from simoc_sam import config
 
@@ -71,6 +73,25 @@ def format_values(sensor_readings_dict, max_rows=None):
             print(f"Error formatting line {line!r}: {e}")
             continue  # skip lines with formatting errors
     return rows[:max_rows] if max_rows else rows
+
+
+FONT = ImageFont.load_default()
+
+def draw_image(width, height, rows):
+    """Draw sensor values on a PIL image and return it."""
+    if not rows:
+        return  # nothing to display
+    image = Image.new("1", (width, height), 0)  # black background
+    draw = ImageDraw.Draw(image)
+    spacing = max(8, height // len(rows))  # calc row height dynamically
+    y = 0
+    for row in rows:
+        if not row.strip():
+            y += 6  # extra spacing for blank lines
+        else:
+            draw.text((0, y), row, font=FONT, fill=255)  # white text
+            y += spacing
+    return image
 
 
 async def mqtt_monitor(sensor_readings_dict):

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -331,7 +331,7 @@ def test_draw_image_blank_rows_add_space():
     white_with_blank = sum(1 for p in image_with_blank.getdata() if p)
     # same text so the same white pixel count, but different images
     assert white_no_blank == white_with_blank
-    assert image_no_blank.getdata() != image_with_blank.getdata()
+    assert image_no_blank.tobytes() != image_with_blank.tobytes()
 
 def test_draw_image_respects_dimensions():
     """Test that draw_image works with different display dimensions."""

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from PIL import Image
+
 from simoc_sam import config
 from simoc_sam.displays import utils
 from simoc_sam.displays.utils import DisplayData
@@ -253,7 +255,6 @@ async def test_mqtt_monitor_handles_json_error(mock_mqtt_message, mock_mqtt_clie
             await wait_until(lambda: processed['value'])
             assert sensor_readings == {}
 
-
 @pytest.mark.asyncio
 async def test_mqtt_monitor_verbose_mode(mock_mqtt_client, capfd):
     """Test that verbose MQTT mode prints received messages."""
@@ -267,7 +268,6 @@ async def test_mqtt_monitor_verbose_mode(mock_mqtt_client, capfd):
             await wait_until(lambda: 'scd30' in sensor_readings)
             captured = capfd.readouterr()
             assert "Received from scd30: {'co2': 450}\n" in captured.out
-
 
 @pytest.mark.asyncio
 async def test_mqtt_monitor_reconnects_on_error(mock_mqtt_client, mock_mqtt_message, capfd):
@@ -294,3 +294,51 @@ async def test_mqtt_monitor_reconnects_on_error(mock_mqtt_client, mock_mqtt_mess
             assert captured.out.count('Connection lost') == 1
             assert captured.out.count('Reconnecting in') >= 1
             assert "Received from scd30: {'co2': 450}\n" in captured.out
+
+
+def test_draw_image_returns_none_for_empty_rows():
+    """Test that draw_image returns None when given no rows."""
+    assert utils.draw_image(128, 128, []) is None
+    assert utils.draw_image(128, 128, None) is None
+
+def test_draw_image_returns_1bit_image():
+    """Test that draw_image returns a 1-bit PIL image of the correct size."""
+    width, height = 128, 64
+    image = utils.draw_image(width, height, ["Test"])
+    assert isinstance(image, Image.Image)
+    assert image.size == (width, height)
+    assert image.mode == "1"
+
+def test_draw_image_black_background():
+    """Test that draw_image renders a black background."""
+    image = utils.draw_image(128, 64, [" "])  # empty line with no text
+    pixels = set(image.getdata())
+    assert pixels == {0}  # all pixels should be black (0)
+
+def test_draw_image_has_white_pixels_for_text():
+    """Test that draw_image renders text as white pixels on black background."""
+    image = utils.draw_image(128, 64, ["Test"])
+    pixels = list(image.getdata())
+    # should only have black (0) and white (255) pixels
+    assert set(pixels) == {0, 255}
+    assert pixels.count(0) > pixels.count(255)  # more black than white
+
+def test_draw_image_blank_rows_add_space():
+    """Test that blank rows add spacing but no text pixels."""
+    image_no_blank = utils.draw_image(128, 64, ["Row 1", "Row 2"])
+    image_with_blank = utils.draw_image(128, 64, ["Row 1", "   ", "Row 2"])
+    white_no_blank = sum(1 for p in image_no_blank.getdata() if p)
+    white_with_blank = sum(1 for p in image_with_blank.getdata() if p)
+    # same text so the same white pixel count, but different images
+    assert white_no_blank == white_with_blank
+    assert image_no_blank.getdata() != image_with_blank.getdata()
+
+def test_draw_image_respects_dimensions():
+    """Test that draw_image works with different display dimensions."""
+    one_row = ["Test"]
+    many_rows = ["Test" * 100] * 100  # shouldn't affect image size
+    for width, height in [(128, 64), (128, 128), (64, 32)]:
+        image = utils.draw_image(width, height, one_row)
+        assert image.size == (width, height)
+        image = utils.draw_image(width, height, many_rows)
+        assert image.size == (width, height)


### PR DESCRIPTION
This PR adds the driver for the ssd1327 grayscale OLED display.
It also moves the `draw_image` function into the `displays/utils.py` module to avoid duplication with the ssd1306 driver.