### PR TITLE
Use UTC timestamps instead of local time

### DIFF
--- a/src/simoc_sam/sensors/basesensor.py
+++ b/src/simoc_sam/sensors/basesensor.py
@@ -3,7 +3,7 @@ import json
 import random
 import socket
 
-from datetime import datetime
+from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 
 import paho.mqtt.client as mqtt
@@ -63,8 +63,8 @@ class BaseSensor(ABC):
         return False  # let exceptions propagate
 
     def get_timestamp(self):
-        """Return the current timestamp as a string."""
-        return datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+        """Return the current timestamp as a UTC ISO 8601 string."""
+        return datetime.now(timezone.utc).isoformat(timespec='seconds')
 
     def sensor_info(self):
         """Return information about the sensor and the value it returns."""

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -4,7 +4,7 @@ import argparse
 import subprocess
 
 from typing import Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -18,9 +18,11 @@ def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
     """Format a sensor reading and return it as a string."""
     r = dict(reading)  # make a copy
     n = r.pop('n')
-    # convert UTC timestamp to local time
-    dt = datetime.fromisoformat(r.pop('timestamp')).astimezone()
-    timestamp = dt.strftime(time_fmt)
+    # convert UTC timestamp to local time; treat naive timestamps as UTC
+    dt = datetime.fromisoformat(r.pop('timestamp'))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    timestamp = dt.astimezone().strftime(time_fmt)
     sensor_id = sensor_info['sensor_id'] if sensor_info else '-'
     reading_info = sensor_info['reading_info'] if sensor_info else None
     result = []

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -18,7 +18,8 @@ def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
     """Format a sensor reading and return it as a string."""
     r = dict(reading)  # make a copy
     n = r.pop('n')
-    dt = datetime.strptime(r.pop('timestamp'), '%Y-%m-%d %H:%M:%S.%f')
+    # convert UTC timestamp to local time
+    dt = datetime.fromisoformat(r.pop('timestamp')).astimezone()
     timestamp = dt.strftime(time_fmt)
     sensor_id = sensor_info['sensor_id'] if sensor_info else '-'
     reading_info = sensor_info['reading_info'] if sensor_info else None

--- a/src/simoc_sam/siobridge.py
+++ b/src/simoc_sam/siobridge.py
@@ -6,7 +6,7 @@ import ipaddress
 import traceback
 
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict, deque
 
 import aiomqtt
@@ -116,8 +116,8 @@ async def register_client(sid):
     SUBSCRIBERS.add(sid)
 
 def get_timestamp():
-    """Return the current timestamp as a string."""
-    return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    """Return the current timestamp as a UTC ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat(timespec='seconds')
 
 async def emit_to_subscribers(*args, **kwargs):
     # TODO: replace with a namespace

--- a/tests/test_csvwriter.py
+++ b/tests/test_csvwriter.py
@@ -39,7 +39,7 @@ def mock_open(monkeypatch):
 
 @pytest.fixture
 def mock_msg():
-    payload = json.dumps(dict(n=0, timestamp='2024-03-06 12:00:00', co2=123))
+    payload = json.dumps(dict(n=0, timestamp='2024-03-06T12:00:00+00:00', co2=123))
     yield mock.Mock(payload=payload.encode('utf-8'), topic='sam/test/scd30')
 
 
@@ -59,13 +59,13 @@ def test_on_message(mock_open, mock_msg, mock_data_dir):
     assert handle.write.call_count == 2
     calls = [
         mock.call('n,timestamp,co2,temperature,humidity\r\n'),  # adds the header
-        mock.call('0,2024-03-06 12:00:00,123,,\r\n'),  # and the readings
+        mock.call('0,2024-03-06T12:00:00+00:00,123,,\r\n'),  # and the readings
     ]
     handle.write.assert_has_calls(calls)
     # now mock tell to return > 0 (file has content)
     mock_open.return_value.tell.return_value = 100
     csvwriter.on_message(client=None, userdata=None, msg=mock_msg)
-    calls.append(mock.call('0,2024-03-06 12:00:00,123,,\r\n'))  # readings only
+    calls.append(mock.call('0,2024-03-06T12:00:00+00:00,123,,\r\n'))  # readings only
     assert handle.write.call_count == 3
     handle.write.assert_has_calls(calls)
 

--- a/tests/test_siobridge.py
+++ b/tests/test_siobridge.py
@@ -74,14 +74,14 @@ def mock_emit_to_subscribers():
 
 @pytest.fixture
 def sensor_reading():
-    return dict(n=8, timestamp='2022-03-04 03:58:02.771409', var=50)
+    return dict(n=8, timestamp='2022-03-04T03:58:02+00:00', var=50)
 
 @pytest.fixture
 def step_batch(sensor_id, sensor_reading):
     """Create a step-batch bundle using the sensor reading."""
     return [{
         'n': 0,
-        'timestamp': '2022-03-04 03:58:02',
+        'timestamp': '2022-03-04T03:58:02+00:00',
         'readings': {sensor_id: sensor_reading}
     }]
 
@@ -93,7 +93,7 @@ def mqtt_message():
     message.topic.value = get_sensor_id('mock', sep='/')
     message.payload = json.dumps({
         'n': 1,
-        'timestamp': '2022-03-04 03:58:02.771409',
+        'timestamp': '2022-03-04T03:58:02+00:00',
         'temperature': 25.5
     }).encode()
     return message
@@ -101,7 +101,7 @@ def mqtt_message():
 @pytest.fixture
 def mock_get_timestamp():
     """Patch get_timestamp to return a predictable value."""
-    with patch('simoc_sam.siobridge.get_timestamp', return_value='2022-03-04 03:58:02'):
+    with patch('simoc_sam.siobridge.get_timestamp', return_value='2022-03-04T03:58:02+00:00'):
         yield
 
 @pytest.fixture


### PR DESCRIPTION
This PR changes the timestamp used internally from local time to UTC, and affects two places:
* the timestamp included by the sensor drivers in the MQTT messages;
* the timestamp sent by the `siobridge` to the frontend (this will need to be changed in the frontend too);

This will make timestamps unambiguous and easily comparable even when they are generated in different timezones.  One downside is that the timezone information is not preserved, but can be extrapolated from the `location` of the MQTT messages.