### PR TITLE
Add a systemd env file that defines runtime variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.diff
 config.py
 configs/simoc_live
+.env

--- a/configs/csvwriter.service
+++ b/configs/csvwriter.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=%h/simoc-sam/.env
+Environment=VENV_PY=/home/pi/simoc-sam/venv/bin/python3
+EnvironmentFile=-%h/simoc-sam/.env
 ExecStart=${VENV_PY} -m simoc_sam.csvwriter
 Restart=always
 RestartSec=5

--- a/configs/csvwriter.service
+++ b/configs/csvwriter.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.csvwriter
+EnvironmentFile=%h/simoc-sam/.env
+ExecStart=${VENV_PY} -m simoc_sam.csvwriter
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/configs/display-runner@.service
+++ b/configs/display-runner@.service
@@ -15,7 +15,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.displays.%i
+EnvironmentFile=%h/simoc-sam/.env
+ExecStart=${VENV_PY} -m simoc_sam.displays.%i
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/configs/display-runner@.service
+++ b/configs/display-runner@.service
@@ -15,7 +15,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=%h/simoc-sam/.env
+Environment=VENV_PY=/home/pi/simoc-sam/venv/bin/python3
+EnvironmentFile=-%h/simoc-sam/.env
 ExecStart=${VENV_PY} -m simoc_sam.displays.%i
 Restart=always
 RestartSec=5

--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -17,7 +17,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=%h/simoc-sam/.env
+Environment=VENV_PY=/home/pi/simoc-sam/venv/bin/python3
+EnvironmentFile=-%h/simoc-sam/.env
 ExecStart=${VENV_PY} -m simoc_sam.sensors.%i -v --mqtt
 Restart=always
 RestartSec=5

--- a/configs/sensor-runner@.service
+++ b/configs/sensor-runner@.service
@@ -17,7 +17,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.sensors.%i -v --mqtt
+EnvironmentFile=%h/simoc-sam/.env
+ExecStart=${VENV_PY} -m simoc_sam.sensors.%i -v --mqtt
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/configs/siobridge.service
+++ b/configs/siobridge.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.siobridge
+EnvironmentFile=%h/simoc-sam/.env
+ExecStart=${VENV_PY} -m simoc_sam.siobridge
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/configs/siobridge.service
+++ b/configs/siobridge.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=%h/simoc-sam/.env
+Environment=VENV_PY=/home/pi/simoc-sam/venv/bin/python3
+EnvironmentFile=-%h/simoc-sam/.env
 ExecStart=${VENV_PY} -m simoc_sam.siobridge
 Restart=always
 RestartSec=5

--- a/configs/sqlwriter.service
+++ b/configs/sqlwriter.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/home/pi/simoc-sam/venv/bin/python -m simoc_sam.sqlwriter
+EnvironmentFile=%h/simoc-sam/.env
+ExecStart=${VENV_PY} -m simoc_sam.sqlwriter
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/configs/sqlwriter.service
+++ b/configs/sqlwriter.service
@@ -12,7 +12,8 @@ After=network.target
 User=pi
 WorkingDirectory=/home/pi/simoc-sam
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=%h/simoc-sam/.env
+Environment=VENV_PY=/home/pi/simoc-sam/venv/bin/python3
+EnvironmentFile=-%h/simoc-sam/.env
 ExecStart=${VENV_PY} -m simoc_sam.sqlwriter
 Restart=always
 RestartSec=5

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -155,7 +155,7 @@ def copy_repo(target, *, exclude_venv=True, exclude_git=True):
     user = user or 'pi'
     path = path or '/home/pi/simoc-sam'
     repo = f'{pathlib.Path(__file__).parent}/'  # rsync wants the trailing /
-    excludes = ['--exclude', '**/__pycache__']
+    excludes = ['--exclude', '**/__pycache__', '--exclude', '.env']
     if exclude_venv:
         excludes.extend(['--exclude', 'venv'])
     if exclude_git:

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -132,6 +132,7 @@ def update():
         print('Code updated successfully.')
     else:
         print('Update failed: see error log above for details.')
+    write_service_env_file()  # update .env file
     return success
 
 
@@ -356,8 +357,18 @@ def teardown_mosquitto():
     mosquitto_conf_dest.unlink(missing_ok=True)
 
 
+def write_service_env_file():
+    """Create environment file for systemd services."""
+    env_vars = {
+        'VENV_PY': VENV_PY,
+    }
+    env_file = SIMOC_SAM_DIR / '.env'
+    env_file.write_text(''.join(f'{k}={v}\n' for k, v in env_vars.items()))
+    print(f'Service environment file written to {env_file}')
+
 def setup_systemd_unit(name, unit_type='service', enable=True, start=True):
     """Setup a systemd unit by creating symlink and optionally enabling/starting."""
+    write_service_env_file()
     unit_name = f'{name}.{unit_type}'
     if '@' in name:
         # handle templates, e.g. sensor-runner@scd30 -> sensor-runner@.service

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -374,11 +374,16 @@ def write_service_env_file():
         'VENV_PY': VENV_PY,
     }
     env_file = SIMOC_SAM_DIR / '.env'
-    env_file.write_text(''.join(f'{k}={v}\n' for k, v in env_vars.items()))
+    content = ''.join(f'{k}={v}\n' for k, v in env_vars.items())
+    # write to a temp file in the same dir, then atomically replace
+    with tempfile.NamedTemporaryFile(mode='w', dir=SIMOC_SAM_DIR, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = pathlib.Path(tmp.name)
     # ensure the file is accessible/editable by other commands without sudo
     if RUNNING_WITH_SUDO:
         pw = pwd.getpwnam(USER)
-        os.chown(env_file, pw.pw_uid, pw.pw_gid)
+        os.chown(tmp_path, pw.pw_uid, pw.pw_gid)
+    os.replace(tmp_path, env_file)
     print(f'Service environment file written to {env_file}')
 
 def setup_systemd_unit(name, unit_type='service', enable=True, start=True):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -27,10 +27,11 @@ except ModuleNotFoundError:
     config = None
 
 
-RUNNING_WITH_SUDO = os.geteuid() == 0 and os.environ.get('SUDO_USER')
+SUDO_USER = os.environ.get('SUDO_USER')  # the original user who invoked sudo
+RUNNING_WITH_SUDO = os.geteuid() == 0 and bool(SUDO_USER)
 if RUNNING_WITH_SUDO:
     # non-root user running the script with sudo
-    USER = os.environ['SUDO_USER']
+    USER = SUDO_USER
     HOME = pathlib.Path(pwd.getpwnam(USER).pw_dir)
 else:
     # script is run without sudo, or by root directly

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import pwd
 import uuid
 import shutil
 import socket
@@ -26,7 +27,17 @@ except ModuleNotFoundError:
     config = None
 
 
-HOME = pathlib.Path.home()
+RUNNING_WITH_SUDO = os.geteuid() == 0 and os.environ.get('SUDO_USER')
+if RUNNING_WITH_SUDO:
+    # non-root user running the script with sudo
+    USER = os.environ['SUDO_USER']
+    HOME = pathlib.Path(pwd.getpwnam(USER).pw_dir)
+else:
+    # script is run without sudo, or by root directly
+    HOME = pathlib.Path.home()
+    USER = os.environ.get('USER') or os.environ.get('LOGNAME')
+HOSTNAME = socket.gethostname()
+
 SIMOC_SAM_DIR = pathlib.Path(__file__).resolve().parent
 CONFIGS_DIR = SIMOC_SAM_DIR / 'configs'
 RPI_CONFIG = pathlib.Path('/boot/firmware/config.txt')
@@ -41,7 +52,6 @@ VENV_PY = str(VENV_DIR / 'bin' / 'python3')
 DEPS = SIMOC_SAM_DIR / 'requirements.txt'
 DEV_DEPS = SIMOC_SAM_DIR / 'dev-requirements.txt'
 TMUX_SNAME = 'SAM'  # tmux session name
-HOSTNAME = socket.gethostname()
 
 APT_INSTALL = ['nmap', 'vim', 'tcpdump', 'tmux', 'nginx', 'avahi-utils',
                'mosquitto', 'mosquitto-clients', 'util-linux-extra']
@@ -364,6 +374,10 @@ def write_service_env_file():
     }
     env_file = SIMOC_SAM_DIR / '.env'
     env_file.write_text(''.join(f'{k}={v}\n' for k, v in env_vars.items()))
+    # ensure the file is accessible/editable by other commands without sudo
+    if RUNNING_WITH_SUDO:
+        pw = pwd.getpwnam(USER)
+        os.chown(env_file, pw.pw_uid, pw.pw_gid)
     print(f'Service environment file written to {env_file}')
 
 def setup_systemd_unit(name, unit_type='service', enable=True, start=True):

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -35,8 +35,8 @@ if RUNNING_WITH_SUDO:
     HOME = pathlib.Path(pwd.getpwnam(USER).pw_dir)
 else:
     # script is run without sudo, or by root directly
-    HOME = pathlib.Path.home()
     USER = os.environ.get('USER') or os.environ.get('LOGNAME')
+    HOME = pathlib.Path.home()
 HOSTNAME = socket.gethostname()
 
 SIMOC_SAM_DIR = pathlib.Path(__file__).resolve().parent


### PR DESCRIPTION
This PR adds an environment file which contains runtime variables to be used by systemd services, as described in:
* #396

Currently it only defines the `VENV_PY` variable, but by introducing the `.env` file and adding it to the services units, it allows us to easily inject more variables when needed.  The username and working dir are still hardcoded, but that can be fixed in a separate PR.