### PR TITLE
Optimize Live dashboard

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,6 +48,8 @@ let datePicker = null;
 let timeStartPicker = null;
 let timeEndPicker = null;
 let selectionUIReady = null;
+let sensorsRefreshedAt = 0;
+const SENSORS_TTL = 5 * 60 * 1000;  // refresh sensor metadata every 5 minutes
 
 const $ = (sel) => document.querySelector(sel);
 
@@ -111,19 +113,25 @@ function stopPolling() {
 }
 
 async function refreshLive() {
-  let sensors, latest;
+  if (!Object.keys(state.sensors).length) {
+    await selectionUIReady;  // ensure sensor metadata is ready before first render
+  }
+  // Background-refresh sensor metadata periodically (non-blocking).
+  if (Date.now() - sensorsRefreshedAt > SENSORS_TTL) {
+    fetchJSON('/api/sensors')
+      .then(data => { state.sensors = data.sensors; sensorsRefreshedAt = Date.now(); })
+      .catch(() => {});  // non-fatal: keep using cached metadata
+  }
+  $('#live-status').textContent = 'Loading\u2026';
+  let latest;
   try {
-    [sensors, latest] = await Promise.all([
-      fetchJSON('/api/sensors'),
-      fetchJSON('/api/latest'),
-    ]);
+    latest = await fetchJSON('/api/latest');
   } catch (err) {
-    $('#live-status').textContent = `Error fetching data: ${err.message}`;
+    $('#live-status').textContent = `Error: ${err.message}`;
     return;
   }
-  state.sensors = sensors.sensors;
   $('#live-status').textContent = `Last update: ${formatTimeNow()}`;
-  renderLiveCards(sensors.sensors, latest.sensors);
+  renderLiveCards(state.sensors, latest.sensors);
 }
 
 function renderLiveCards(sensors, latest) {
@@ -554,7 +562,9 @@ if (_savedViewMode) {
 }
 if (_savedQuickRange) applyQuickRange(_savedQuickRange);
 _restoringPrefs = false;
-selectionUIReady = buildSelectionUI().catch((err) => {
-  $('#history-status').textContent = `Error loading sensors: ${err.message}`;
-});
+selectionUIReady = buildSelectionUI()
+  .then(() => { sensorsRefreshedAt = Date.now(); })
+  .catch((err) => {
+    $('#history-status').textContent = `Error loading sensors: ${err.message}`;
+  });
 startPolling();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,8 +48,9 @@ let datePicker = null;
 let timeStartPicker = null;
 let timeEndPicker = null;
 let selectionUIReady = null;
-let sensorsRefreshedAt = 0;
-const SENSORS_TTL = 5 * 60 * 1000;  // refresh sensor metadata every 5 minutes
+let activeSensors = new Set();   // sensors known to have data (grow-only)
+let discoveryLastRun = 0;
+const DISCOVERY_TTL = 5 * 60 * 1000;  // re-check for new sensors every 5 minutes
 
 const $ = (sel) => document.querySelector(sel);
 
@@ -116,21 +117,21 @@ async function refreshLive() {
   if (!Object.keys(state.sensors).length) {
     await selectionUIReady;  // ensure sensor metadata is ready before first render
   }
-  // Background-refresh sensor metadata periodically (non-blocking).
-  if (Date.now() - sensorsRefreshedAt > SENSORS_TTL) {
-    sensorsRefreshedAt = Date.now();
-    fetchJSON('/api/sensors')
-      .then(data => { state.sensors = data.sensors; })
-      .catch(() => {});  // non-fatal: keep using cached metadata
-  }
+  // Full discovery every 5 minutes to detect newly active sensors.
+  const isDiscovery = Date.now() - discoveryLastRun > DISCOVERY_TTL;
+  if (isDiscovery) discoveryLastRun = Date.now();
+  const url = (isDiscovery || !activeSensors.size)
+    ? '/api/latest'
+    : `/api/latest?sensors=${[...activeSensors].join(',')}`;
   $('#live-status').textContent = 'Loading\u2026';
   let latest;
   try {
-    latest = await fetchJSON('/api/latest');
+    latest = await fetchJSON(url);
   } catch (err) {
     $('#live-status').textContent = `Error: ${err.message}`;
     return;
   }
+  for (const sensor of Object.keys(latest.sensors)) activeSensors.add(sensor);
   $('#live-status').textContent = `Last update: ${formatTimeNow()}`;
   renderLiveCards(state.sensors, latest.sensors);
 }
@@ -139,10 +140,11 @@ function renderLiveCards(sensors, latest) {
   const container = $('#live-cards');
   container.replaceChildren();
   for (const [sensor, info] of Object.entries(sensors)) {
+    if (!activeSensors.has(sensor)) continue;  // skip sensors that never had data
     const reading = latest[sensor];
-    if (!reading && !info.active) continue;  // skip sensors with no data
+    const isActive = reading?.active ?? false;
     const card = document.createElement('div');
-    card.className = info.active ? 'card active' : 'card';
+    card.className = isActive ? 'card active' : 'card';
     const rows = Object.entries(info.metrics).map(([metric, meta]) => {
       const value = reading?.[metric];
       const display = (value === null || value === undefined) ? '--'
@@ -167,14 +169,21 @@ function renderLiveCards(sensors, latest) {
 /* ---------- sensor + metric selection ---------- */
 
 async function buildSelectionUI() {
-  const data = await fetchJSON('/api/sensors');
-  state.sensors = data.sensors;
+  const [sensorsData, latestData] = await Promise.all([
+    fetchJSON('/api/sensors'),
+    fetchJSON('/api/latest'),   // discover which sensors have data
+  ]);
+  state.sensors = sensorsData.sensors;
+  for (const sensor of Object.keys(latestData.sensors)) activeSensors.add(sensor);
+  discoveryLastRun = Date.now();
   const fieldset = $('#sensor-selection');
   const sensorControls = {};  // sensor -> {sensorBtn, metricBtns: {metric -> btn}}
-  for (const [sensor, info] of Object.entries(data.sensors)) {
-    if (!info.has_data) continue;  // skip sensors with no DB rows
+  for (const [sensor, info] of Object.entries(sensorsData.sensors)) {
+    if (!activeSensors.has(sensor)) continue;  // skip sensors with no DB rows
+    const reading = latestData.sensors[sensor];
+    const isActive = reading?.active ?? false;
     const row = document.createElement('div');
-    row.className = info.active ? 'sensor-row' : 'sensor-row stale';
+    row.className = isActive ? 'sensor-row' : 'sensor-row stale';
     const sensorBtn = document.createElement('button');
     sensorBtn.type = 'button';
     sensorBtn.className = 'toggle sensor';
@@ -564,7 +573,6 @@ if (_savedViewMode) {
 if (_savedQuickRange) applyQuickRange(_savedQuickRange);
 _restoringPrefs = false;
 selectionUIReady = buildSelectionUI()
-  .then(() => { sensorsRefreshedAt = Date.now(); })
   .catch((err) => {
     $('#history-status').textContent = `Error loading sensors: ${err.message}`;
   });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -118,8 +118,9 @@ async function refreshLive() {
   }
   // Background-refresh sensor metadata periodically (non-blocking).
   if (Date.now() - sensorsRefreshedAt > SENSORS_TTL) {
+    sensorsRefreshedAt = Date.now();
     fetchJSON('/api/sensors')
-      .then(data => { state.sensors = data.sensors; sensorsRefreshedAt = Date.now(); })
+      .then(data => { state.sensors = data.sensors; })
       .catch(() => {});  // non-fatal: keep using cached metadata
   }
   $('#live-status').textContent = 'Loading\u2026';

--- a/src/simoc_sam/api.py
+++ b/src/simoc_sam/api.py
@@ -164,6 +164,8 @@ def create_app(db_path=None):
             metrics = list(sensor_data.data.keys())
             t0 = time.perf_counter()
             try:
+                # Assumes that the most recent reading has the highest id
+                # (much faster than ordering by timestamp).
                 row = conn.execute(
                     f'SELECT sensor_id, timestamp, {", ".join(metrics)} '
                     f'FROM {sensor} ORDER BY id DESC LIMIT 1'

--- a/src/simoc_sam/api.py
+++ b/src/simoc_sam/api.py
@@ -80,9 +80,9 @@ def create_app(db_path=None):
         for sensor in SENSOR_DATA:
             try:
                 row = conn.execute(
-                    f'SELECT MAX(timestamp) FROM {sensor}'
+                    f'SELECT timestamp FROM {sensor} ORDER BY id DESC LIMIT 1'
                 ).fetchone()
-                latest[sensor] = row[0]
+                latest[sensor] = row[0] if row else None
             except sqlite3.OperationalError:
                 latest[sensor] = None  # missing sensor table
         return latest
@@ -170,7 +170,7 @@ def create_app(db_path=None):
             try:
                 row = conn.execute(
                     f'SELECT sensor_id, timestamp, {", ".join(metrics)} '
-                    f'FROM {sensor} ORDER BY timestamp DESC LIMIT 1'
+                    f'FROM {sensor} ORDER BY id DESC LIMIT 1'
                 ).fetchone()
             except sqlite3.OperationalError:
                 continue  # missing sensor table

--- a/src/simoc_sam/api.py
+++ b/src/simoc_sam/api.py
@@ -77,6 +77,7 @@ def create_app(db_path=None):
     def get_latest_timestamps(conn):
         """Return a dict of sensor -> latest timestamp (ISO string or None)."""
         latest = {}
+        t_total = time.perf_counter()
         for sensor in SENSOR_DATA:
             try:
                 row = conn.execute(
@@ -85,6 +86,9 @@ def create_app(db_path=None):
                 latest[sensor] = row[0] if row else None
             except sqlite3.OperationalError:
                 latest[sensor] = None  # missing sensor table
+        n_active = sum(1 for v in latest.values() if v is not None)
+        app.logger.info('get_latest_timestamps: %.3fs, %d/%d sensors with data',
+                        time.perf_counter() - t_total, n_active, len(latest))
         return latest
 
     def parse_selection(payload):
@@ -165,8 +169,10 @@ def create_app(db_path=None):
         """Return the latest reading for each sensor that has data."""
         conn = get_db()
         sensors = {}
+        t_total = time.perf_counter()
         for sensor, sensor_data in SENSOR_DATA.items():
             metrics = list(sensor_data.data.keys())
+            t0 = time.perf_counter()
             try:
                 row = conn.execute(
                     f'SELECT sensor_id, timestamp, {", ".join(metrics)} '
@@ -174,6 +180,7 @@ def create_app(db_path=None):
                 ).fetchone()
             except sqlite3.OperationalError:
                 continue  # missing sensor table
+            app.logger.info('api_latest(%s): %.3fs', sensor, time.perf_counter() - t0)
             if row is None:
                 continue
             sensor_id, timestamp, *values = row
@@ -182,6 +189,8 @@ def create_app(db_path=None):
                 'timestamp': timestamp,
                 **dict(zip(metrics, values)),
             }
+        app.logger.info('api_latest total: %.3fs, %d sensors',
+                        time.perf_counter() - t_total, len(sensors))
         return jsonify({'sensors': sensors})
 
     @app.post('/api/query')

--- a/src/simoc_sam/api.py
+++ b/src/simoc_sam/api.py
@@ -74,23 +74,6 @@ def create_app(db_path=None):
         app.logger.exception('Unhandled exception')
         return jsonify({'error': 'Internal server error'}), 500
 
-    def get_latest_timestamps(conn):
-        """Return a dict of sensor -> latest timestamp (ISO string or None)."""
-        latest = {}
-        t_total = time.perf_counter()
-        for sensor in SENSOR_DATA:
-            try:
-                row = conn.execute(
-                    f'SELECT timestamp FROM {sensor} ORDER BY id DESC LIMIT 1'
-                ).fetchone()
-                latest[sensor] = row[0] if row else None
-            except sqlite3.OperationalError:
-                latest[sensor] = None  # missing sensor table
-        n_active = sum(1 for v in latest.values() if v is not None)
-        app.logger.info('get_latest_timestamps: %.3fs, %d/%d sensors with data',
-                        time.perf_counter() - t_total, n_active, len(latest))
-        return latest
-
     def parse_selection(payload):
         """Validate and return (start, end, selection, limit) from a request payload."""
         if not payload:
@@ -140,37 +123,44 @@ def create_app(db_path=None):
 
     @app.get('/api/sensors')
     def api_sensors():
-        """Return configured sensors with metric metadata and active state."""
-        conn = get_db()
-        latest = get_latest_timestamps(conn)
-        threshold = timedelta(seconds=max(600, config.sensor_read_delay))
-        now = datetime.now(timezone.utc)
-        sensors = {}
-        for sensor, sensor_data in SENSOR_DATA.items():
-            ts = latest.get(sensor)
-            has_data = ts is not None
-            active = (has_data and
-                      now - parse_timestamp(ts) <= threshold)
-            sensors[sensor] = {
+        """Return static sensor metadata from sensors.toml (no DB queries).
+
+        The response only changes when sensors.toml changes; clients should
+        cache it and only refetch after a page reload.
+        """
+        sensors = {
+            sensor: {
                 'name': sensor_data.name,
                 'description': sensor_data.description,
-                'has_data': has_data,
-                'active': active,
                 'metrics': {
                     metric: {'label': info.get('label', metric),
                              'unit': info.get('unit', '')}
                     for metric, info in sensor_data.data.items()
                 },
             }
+            for sensor, sensor_data in SENSOR_DATA.items()
+        }
         return jsonify({'sensors': sensors})
 
     @app.get('/api/latest')
     def api_latest():
-        """Return the latest reading for each sensor that has data."""
+        """Return the latest reading for each sensor that has data.
+
+        Accepts optional ?sensors=name1,name2 to limit which sensors are queried.
+        Without a filter all configured sensors are queried (used for discovery).
+        """
         conn = get_db()
-        sensors = {}
+        requested = request.args.get('sensors', '')
+        sensors_to_query = (
+            [s for s in requested.split(',') if s in SENSOR_DATA]
+            if requested else list(SENSOR_DATA.keys())
+        )
+        threshold = timedelta(seconds=max(600, config.sensor_read_delay))
+        now = datetime.now(timezone.utc)
+        result = {}
         t_total = time.perf_counter()
-        for sensor, sensor_data in SENSOR_DATA.items():
+        for sensor in sensors_to_query:
+            sensor_data = SENSOR_DATA[sensor]
             metrics = list(sensor_data.data.keys())
             t0 = time.perf_counter()
             try:
@@ -184,14 +174,15 @@ def create_app(db_path=None):
             if row is None:
                 continue
             sensor_id, timestamp, *values = row
-            sensors[sensor] = {
+            result[sensor] = {
                 'sensor_id': sensor_id,
                 'timestamp': timestamp,
+                'active': now - parse_timestamp(timestamp) <= threshold,
                 **dict(zip(metrics, values)),
             }
-        app.logger.info('api_latest total: %.3fs, %d sensors',
-                        time.perf_counter() - t_total, len(sensors))
-        return jsonify({'sensors': sensors})
+        app.logger.info('api_latest total: %.3fs, %d/%d sensors',
+                        time.perf_counter() - t_total, len(result), len(sensors_to_query))
+        return jsonify({'sensors': result})
 
     @app.post('/api/query')
     def api_query():

--- a/src/simoc_sam/db.py
+++ b/src/simoc_sam/db.py
@@ -124,6 +124,8 @@ def get_readings(sensor, *, conn=None, sensor_id=None, location=None, host=None,
     if decimate:
         # Two O(log N) index seeks give the rowid range of matching rows.
         # Fast when WHERE uses an indexed column (e.g. sensor_id).
+        # Assumes rows are inserted in timestamp order so the id range
+        # corresponds to the timestamp range.
         boundary_sql = f'SELECT id FROM {sensor} {where} ORDER BY timestamp'
         first_row = conn.execute(f'{boundary_sql} ASC LIMIT 1', params).fetchone()
         if first_row is None:

--- a/src/simoc_sam/db.py
+++ b/src/simoc_sam/db.py
@@ -134,9 +134,10 @@ def get_readings(sensor, *, conn=None, sensor_id=None, location=None, host=None,
             # Fewer candidate rows than target; return all matching rows.
             cursor = conn.execute(full_sql, params)
         else:
-            # Fetch only evenly-spaced rows by rowid, skipping the rest.
-            stride = max(1, (last_id - first_id) // ((decimate - 1) or 1))
-            target_ids = list(range(first_id, last_id + 1, stride))[:decimate]
+            # Evenly-spaced rowid targets spanning first_id..last_id inclusive.
+            # Integer linspace: target[i] = first + (last-first)*i//(n-1).
+            target_ids = [first_id + (last_id - first_id) * i // ((decimate - 1) or 1)
+                          for i in range(decimate)]
             id_placeholders = ','.join('?' * len(target_ids))
             extra = f' AND {" AND ".join(conditions)}' if conditions else ''
             cursor = conn.execute(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,33 +66,29 @@ def test_sensors_metric_metadata(client):
 
 def test_sensors_inactive_when_empty(client):
     data = client.get('/api/sensors').get_json()
-    assert all(not s['active'] for s in data['sensors'].values())
+    # static endpoint — no active/has_data fields
+    assert all('active' not in s for s in data['sensors'].values())
+    assert all('has_data' not in s for s in data['sensors'].values())
 
-def test_sensors_no_has_data_when_empty(client):
-    data = client.get('/api/sensors').get_json()
-    assert all(not s['has_data'] for s in data['sensors'].values())
-
-def test_sensors_has_data_true_with_any_data(client, db_conn):
-    # even very old data counts
-    insert_row(db_conn, 'scd30', timestamp=make_timestamp(-86400 * 30), co2=700)
-    data = client.get('/api/sensors').get_json()
-    assert data['sensors']['scd30']['has_data'] is True
-
-def test_sensors_has_data_false_for_empty_sensor(client, db_conn):
-    insert_row(db_conn, 'scd30', co2=700)
-    data = client.get('/api/sensors').get_json()
-    assert data['sensors']['bme688']['has_data'] is False
 
 def test_sensors_tolerates_missing_table(tmp_path):
     """Sensors added to sensors.toml before sqlwriter runs have no table yet."""
-    # open a DB with no tables at all
     app = create_app(db_path=tmp_path / 'empty.db')
     app.config['TESTING'] = True
     with app.test_client() as c:
         response = c.get('/api/sensors')
         assert response.status_code == 200
         data = response.get_json()
-        assert all(not s['has_data'] for s in data['sensors'].values())
+        # static endpoint always lists all configured sensors
+        assert 'scd30' in data['sensors']
+
+
+# --- /api/latest ---
+
+def test_latest_empty_db(client):
+    data = client.get('/api/latest').get_json()
+    assert data == {'sensors': {}}
+
 
 def test_latest_tolerates_missing_table(tmp_path):
     """api/latest returns empty sensors dict when no tables exist."""
@@ -103,22 +99,33 @@ def test_latest_tolerates_missing_table(tmp_path):
         assert response.status_code == 200
         assert response.get_json() == {'sensors': {}}
 
-def test_sensors_active_with_recent_data(client, db_conn):
+
+def test_latest_has_data_appears_in_response(client, db_conn):
+    insert_row(db_conn, 'scd30', co2=700)
+    data = client.get('/api/latest').get_json()
+    assert 'scd30' in data['sensors']
+    assert 'bme688' not in data['sensors']  # no rows inserted
+
+
+def test_latest_active_with_recent_data(client, db_conn):
     insert_row(db_conn, 'scd30', timestamp=make_timestamp(), co2=700)
-    data = client.get('/api/sensors').get_json()
+    data = client.get('/api/latest').get_json()
     assert data['sensors']['scd30']['active'] is True
 
-def test_sensors_inactive_with_old_data(client, db_conn):
+
+def test_latest_inactive_with_old_data(client, db_conn):
     insert_row(db_conn, 'scd30', timestamp=make_timestamp(-3600), co2=700)
-    data = client.get('/api/sensors').get_json()
+    data = client.get('/api/latest').get_json()
     assert data['sensors']['scd30']['active'] is False
 
 
-# --- /api/latest ---
+def test_latest_sensor_filter(client, db_conn):
+    insert_row(db_conn, 'scd30', co2=700)
+    insert_row(db_conn, 'bme688', temperature=21.0)
+    data = client.get('/api/latest?sensors=scd30').get_json()
+    assert 'scd30' in data['sensors']
+    assert 'bme688' not in data['sensors']
 
-def test_latest_empty_db(client):
-    data = client.get('/api/latest').get_json()
-    assert data == {'sensors': {}}
 
 def test_latest_returns_most_recent(client, db_conn):
     insert_row(db_conn, 'scd30', n=0,


### PR DESCRIPTION
This PR optimizes the Live dashboard by introducing two major changes:
* The list of sensors metadata is now fetched only once at the beginning, the list of active sensors every 5 minutes, and the readings from the active sensors every 5 seconds;
* The SQL query used to retrieve the latest timestamp now assume that the timestamps are already sorted and retrieves the last value directly, instead of scanning the whole content of the tables finding the most recent timestamp.