### PR TITLE
Revert Adafruit-Blinka to 9.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ gunicorn==26.0.0
 
 # sensor-related deps
 hidapi==0.15.0
-Adafruit-Blinka==9.2.0
+Adafruit-Blinka==9.1.0
 adafruit-circuitpython-scd30==2.3.0
 adafruit-circuitpython-scd4x==1.4.12
 adafruit-circuitpython-sgp30==3.0.16


### PR DESCRIPTION
See:
* https://github.com/adafruit/Adafruit_Blinka/issues/1121