### PR TITLE
Improve display support

### DIFF
--- a/hostinfo.py
+++ b/hostinfo.py
@@ -58,7 +58,7 @@ def print_batman():
 # Devices info
 
 def print_MCP2221_info():
-    """Print True if the MCP2221 is connected, False otherwise."""
+    """Print a message if the MCP2221 is detected, nothing otherwise."""
     from simoc_sam.sensors import utils
     if utils.has_mcp2221():
         print('MCP2221 detected')

--- a/hostinfo.py
+++ b/hostinfo.py
@@ -55,25 +55,25 @@ def print_batman():
     subprocess.run(['sudo', 'batctl', 'o'])
 
 
-# Sensors info
+# Devices info
 
 def print_MCP2221_info():
     """Print True if the MCP2221 is connected, False otherwise."""
     from simoc_sam.sensors import utils
     print(f'MCP2221 connected: {utils.has_mcp2221()}')
 
-def print_sensors():
-    """Print a list of connected sensors and their I2C addresses."""
+def print_devices():
+    """Print a list of connected I2C devices and their addresses."""
     from simoc_sam import utils
     try:
         addresses = utils.get_i2c_addresses()
     except RuntimeError as err:
-        print(f'Sensor scanning failed: {err}')
+        print(f'Device scanning failed: {err}')
         return
     if not addresses:
-        print('No sensors found.')
+        print('No I2C devices found.')
         return
-    print(f'Found {len(addresses)} sensors:')
+    print(f'Found {len(addresses)} I2C device(s):')
     for addr in addresses:
         name = utils.i2c_to_device_name(addr)
         print(f'* {name} (I2C addr: {addr:x})')
@@ -195,15 +195,15 @@ def print_network_info():
     else:
         print("Can't import the netifaces module.")
 
-def print_sensors_info():
+def print_devices_info():
     print_MCP2221_info()
-    print_sensors()
+    print_devices()
 
 def print_info():
     print('===== Network info =====')
     print_network_info()
-    print('\n===== Sensors info =====')
-    print_sensors_info()
+    print('\n===== Devices info =====')
+    print_devices_info()
     print('\n===== Services info =====')
     print_services()
 

--- a/hostinfo.py
+++ b/hostinfo.py
@@ -60,7 +60,8 @@ def print_batman():
 def print_MCP2221_info():
     """Print True if the MCP2221 is connected, False otherwise."""
     from simoc_sam.sensors import utils
-    print(f'MCP2221 connected: {utils.has_mcp2221()}')
+    if utils.has_mcp2221():
+        print('MCP2221 detected')
 
 def print_devices():
     """Print a list of connected I2C devices and their addresses."""

--- a/simoc-sam.py
+++ b/simoc-sam.py
@@ -578,7 +578,7 @@ def run_tmux(file='mqtt'):
 @cmd
 @needs_venv
 def info():
-    """Print host info about the network and sensors."""
+    """Print host info about the network and devices."""
     import hostinfo
     hostinfo.print_info()
 
@@ -591,10 +591,10 @@ def network_info():
 
 @cmd
 @needs_venv
-def sensors_info():
-    """Print info about the connected sensors."""
+def devices_info():
+    """Print info about the connected I2C devices."""
     import hostinfo
-    hostinfo.print_sensors_info()
+    hostinfo.print_devices_info()
 
 @cmd
 def services_info():

--- a/src/simoc_sam/displays/displays.toml
+++ b/src/simoc_sam/displays/displays.toml
@@ -6,7 +6,6 @@ description = "A mock display that prints to console."
 module = "simoc_sam.displays.mockdisplay"
 width = 128
 height = 64
-i2c_address = 0x00
 
 [ssd1306]
 name = "SSD1306"

--- a/src/simoc_sam/displays/utils.py
+++ b/src/simoc_sam/displays/utils.py
@@ -23,7 +23,7 @@ class DisplayData:
     module: str
     width: int
     height: int
-    i2c_address: int
+    i2c_address: int = None
     reset_pin: str = None
 
 
@@ -42,7 +42,7 @@ def load_display_data(file_path=DISPLAYS_TOML):
             module=display_info['module'],
             width=display_info['width'],
             height=display_info['height'],
-            i2c_address=display_info['i2c_address'],
+            i2c_address=display_info.get('i2c_address'),
             reset_pin=display_info.get('reset_pin'),
         )
     return display_data
@@ -51,7 +51,8 @@ def load_display_data(file_path=DISPLAYS_TOML):
 DISPLAY_DATA = load_display_data()
 I2C_TO_DISPLAY_NAMES = defaultdict(list)
 for name, info in DISPLAY_DATA.items():
-    I2C_TO_DISPLAY_NAMES[info.i2c_address].append(name)
+    if info.i2c_address is not None:
+        I2C_TO_DISPLAY_NAMES[info.i2c_address].append(name)
 
 
 def format_values(sensor_readings_dict, max_rows=None):

--- a/src/simoc_sam/sensors/sensors.toml
+++ b/src/simoc_sam/sensors/sensors.toml
@@ -2,7 +2,6 @@
 name = "Mock"
 description = "A mock sensor used for testing."
 module = "simoc_sam.sensors.mocksensor"
-i2c_address = 0x00
 
     [mock.data.co2]
     unit = "ppm"

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -60,7 +60,7 @@ class SensorData:
     name: str
     description: str
     module: str
-    i2c_address: int
+    i2c_address: int = None
     data: Dict[str, Any] = field(default_factory=dict)
     chip_id_register: int = None
     chip_id: int = None
@@ -76,7 +76,7 @@ def load_sensor_data(file_path=SENSORS_TOML):
             name=sensor_info['name'],
             description=sensor_info['description'],
             module=sensor_info['module'],
-            i2c_address=sensor_info['i2c_address'],
+            i2c_address=sensor_info.get('i2c_address'),
             data=sensor_info['data'],
             chip_id_register=sensor_info.get('chip_id_register'),
             chip_id=sensor_info.get('chip_id'),
@@ -86,7 +86,8 @@ def load_sensor_data(file_path=SENSORS_TOML):
 SENSOR_DATA = load_sensor_data()
 I2C_TO_SENSOR_NAMES = defaultdict(list)
 for name, info in SENSOR_DATA.items():
-    I2C_TO_SENSOR_NAMES[info.i2c_address].append(name)
+    if info.i2c_address is not None:
+        I2C_TO_SENSOR_NAMES[info.i2c_address].append(name)
 
 def has_mcp2221():
     return b'MCP2221' in subprocess.check_output("lsusb")

--- a/src/simoc_sam/utils.py
+++ b/src/simoc_sam/utils.py
@@ -79,18 +79,19 @@ def i2c_to_device_name(addr):
         return '<unknown>'
     if len(names) == 1:
         return names[0]
-    # multiple devices with the same address -- probe chip ID to disambiguate
-    # (chip ID disambiguation only applies to sensors)
-    i2c = get_i2c()
-    for name in sensor_names:
-        info = sensor_utils.SENSOR_DATA[name]
-        if info.chip_id_register is not None and info.chip_id is not None:
-            try:
-                result = bytearray(1)
-                i2c.writeto_then_readfrom(addr, bytes([info.chip_id_register]), result)
-                if result[0] == info.chip_id:
-                    return name
-            except (OSError, RuntimeError):
-                continue
+    # multiple devices with the same address
+    if sensor_names:
+        # for sensors, probe chip ID to disambiguate
+        i2c = get_i2c()
+        for name in sensor_names:
+            info = sensor_utils.SENSOR_DATA[name]
+            if info.chip_id_register is not None and info.chip_id is not None:
+                try:
+                    result = bytearray(1)
+                    i2c.writeto_then_readfrom(addr, bytes([info.chip_id_register]), result)
+                    if result[0] == info.chip_id:
+                        return name
+                except (OSError, RuntimeError):
+                    continue
     # Could not disambiguate -- return all candidates
     return '/'.join(names)

--- a/src/simoc_sam/utils.py
+++ b/src/simoc_sam/utils.py
@@ -3,7 +3,6 @@
 import json
 import time
 import asyncio
-import warnings
 
 _i2c_cache = {}
 
@@ -93,10 +92,5 @@ def i2c_to_device_name(addr):
                     return name
             except (OSError, RuntimeError):
                 continue
-    # Could not disambiguate - warn and return first candidate's key
-    warnings.warn(
-        f"Failed to disambiguate device at address {addr:#02x}. "
-        f"Candidates: {names}. Defaulting to '{names[0]}'.",
-        RuntimeWarning
-    )
-    return names[0]
+    # Could not disambiguate -- return all candidates
+    return '/'.join(names)

--- a/src/simoc_sam/utils.py
+++ b/src/simoc_sam/utils.py
@@ -5,8 +5,6 @@ import time
 import asyncio
 import warnings
 
-from .sensors import utils as sensor_utils
-
 _i2c_cache = {}
 
 
@@ -50,6 +48,7 @@ async def read_jsonl_file(file_path):
 
 def get_i2c():
     """Get or create a cached I2C bus instance."""
+    from simoc_sam.sensors import utils as sensor_utils
     if 'i2c' not in _i2c_cache:
         board = sensor_utils.import_board()
         busio = sensor_utils.import_busio()
@@ -72,14 +71,19 @@ def get_i2c_names():
 
 def i2c_to_device_name(addr):
     """Resolve an I2C address to a device name."""
-    names = sensor_utils.I2C_TO_SENSOR_NAMES.get(addr, [])
+    from simoc_sam.sensors import utils as sensor_utils
+    from simoc_sam.displays import utils as display_utils
+    sensor_names = sensor_utils.I2C_TO_SENSOR_NAMES.get(addr, [])
+    display_names = display_utils.I2C_TO_DISPLAY_NAMES.get(addr, [])
+    names = sensor_names + display_names
     if not names:
         return '<unknown>'
     if len(names) == 1:
         return names[0]
     # multiple devices with the same address -- probe chip ID to disambiguate
+    # (chip ID disambiguation only applies to sensors)
     i2c = get_i2c()
-    for name in names:
+    for name in sensor_names:
         info = sensor_utils.SENSOR_DATA[name]
         if info.chip_id_register is not None and info.chip_id is not None:
             try:
@@ -91,7 +95,7 @@ def i2c_to_device_name(addr):
                 continue
     # Could not disambiguate - warn and return first candidate's key
     warnings.warn(
-        f"Failed to disambiguate sensor at address {addr:#02x}. "
+        f"Failed to disambiguate device at address {addr:#02x}. "
         f"Candidates: {names}. Defaulting to '{names[0]}'.",
         RuntimeWarning
     )

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -122,8 +122,8 @@ def test_display_data_i2c_mapping():
     """Test that I2C_TO_DISPLAY_NAMES is correctly populated."""
     assert 0x3D in utils.I2C_TO_DISPLAY_NAMES
     assert 'ssd1306' in utils.I2C_TO_DISPLAY_NAMES[0x3D]
-    assert 0x00 in utils.I2C_TO_DISPLAY_NAMES
-    assert 'mockdisplay' in utils.I2C_TO_DISPLAY_NAMES[0x00]
+    # mockdisplay has no i2c_address and must not appear in the lookup dict
+    assert 'mockdisplay' not in utils.I2C_TO_DISPLAY_NAMES.values()
 
 
 def test_format_values_basic():

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -122,8 +122,8 @@ def test_display_data_i2c_mapping():
     """Test that I2C_TO_DISPLAY_NAMES is correctly populated."""
     assert 0x3D in utils.I2C_TO_DISPLAY_NAMES
     assert 'ssd1306' in utils.I2C_TO_DISPLAY_NAMES[0x3D]
-    # mockdisplay has no i2c_address and must not appear in the lookup dict
-    assert 'mockdisplay' not in utils.I2C_TO_DISPLAY_NAMES.values()
+    # mockdisplay has no i2c_address and must not appear in any lookup list
+    assert all('mockdisplay' not in names for names in utils.I2C_TO_DISPLAY_NAMES.values())
 
 
 def test_format_values_basic():

--- a/tests/test_sensors_utils.py
+++ b/tests/test_sensors_utils.py
@@ -2,6 +2,14 @@ from simoc_sam.sensors import utils
 from simoc_sam import config
 
 
+def test_sensor_data_i2c_mapping():
+    """Test that I2C_TO_SENSOR_NAMES is correctly populated."""
+    assert 0x61 in utils.I2C_TO_SENSOR_NAMES  # scd30
+    assert 'scd30' in utils.I2C_TO_SENSOR_NAMES[0x61]
+    # mock sensor has no i2c_address and must not appear in any lookup list
+    assert all('mock' not in names for names in utils.I2C_TO_SENSOR_NAMES.values())
+
+
 def test_delay():
     # Test that config default is used when no args provided
     args = utils.parse_args([])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ def test_i2c_to_device_name_multiple_candidates(
             result[0] = chip_id
     mock_i2c.writeto_then_readfrom.side_effect = mock_read
     if should_warn:
-        with pytest.warns(RuntimeWarning, match="Failed to disambiguate sensor"):
+        with pytest.warns(RuntimeWarning, match="Failed to disambiguate device"):
             result = utils.i2c_to_device_name(addr)
     else:
         result = utils.i2c_to_device_name(addr)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,6 +64,12 @@ def test_get_i2c_names_known_sensor(mock_i2c):
     result = utils.get_i2c_names()
     assert result == ['tsl2591', 'sgp30', 'scd30']
 
+def test_get_i2c_names_known_display(mock_i2c):
+    """Test that known display addresses are correctly identified."""
+    mock_i2c.scan.return_value = [0x3D]  # ssd1306 / ssd1327
+    result = utils.get_i2c_names()
+    assert result[0] == 'ssd1306/ssd1327'
+
 def test_get_i2c_names_unknown_address(mock_i2c):
     """Test that unknown addresses return '<unknown>'."""
     unknown_addr = 0x99  # Not in sensors.toml
@@ -83,19 +89,24 @@ def test_i2c_to_device_name_known_sensor(mock_i2c):
     result = utils.i2c_to_device_name(0x61)  # scd30
     assert result == 'scd30'
 
+def test_i2c_to_device_name_known_display(mock_i2c):
+    """Test that a known display address is correctly identified."""
+    result = utils.i2c_to_device_name(0x3D)  # ssd1306 or ssd1327
+    assert result == 'ssd1306/ssd1327'
+
 def test_i2c_to_device_name_unknown_address(mock_i2c):
     """Test that unknown address returns '<unknown>'."""
     result = utils.i2c_to_device_name(0x99)  # Not in sensors.toml
     assert result == '<unknown>'
 
-@pytest.mark.parametrize("chip_id_register,chip_id,expected_name,should_warn", [
-    (0xD0, 0x61, 'bme688', False),  # BME688 register with BME688 chip ID
-    (0x00, 0x50, 'bmp388', False),  # BMP388 register with BMP388 chip ID
-    (0xD0, 0x50, 'bme688', True),   # Wrong chip ID - warns and falls back
-    (0x00, 0x61, 'bme688', True),   # Wrong chip ID - warns and falls back
+@pytest.mark.parametrize("chip_id_register,chip_id,expected_name", [
+    (0xD0, 0x61, 'bme688'),           # BME688 chip ID matches
+    (0x00, 0x50, 'bmp388'),           # BMP388 chip ID matches
+    (0xD0, 0x50, 'bme688/bmp388'),    # Probing fails, returns all candidates
+    (0x00, 0x61, 'bme688/bmp388'),    # Probing fails, returns all candidates
 ])
 def test_i2c_to_device_name_multiple_candidates(
-    mock_i2c, chip_id_register, chip_id, expected_name, should_warn):
+    mock_i2c, chip_id_register, chip_id, expected_name):
     """Test chip ID disambiguation for sensors sharing address 0x77."""
     addr = 0x77  # Shared by BME688 and BMP388
     # Simulate device responding with the specified chip ID
@@ -103,11 +114,7 @@ def test_i2c_to_device_name_multiple_candidates(
         if address == addr and reg_bytes == bytes([chip_id_register]):
             result[0] = chip_id
     mock_i2c.writeto_then_readfrom.side_effect = mock_read
-    if should_warn:
-        with pytest.warns(RuntimeWarning, match="Failed to disambiguate device"):
-            result = utils.i2c_to_device_name(addr)
-    else:
-        result = utils.i2c_to_device_name(addr)
+    result = utils.i2c_to_device_name(addr)
     assert result == expected_name
 
 


### PR DESCRIPTION
This PR improves display support by introducing the following changes:
* functions and messages now use "device" instead of just "sensor";
* the `sensors-info` command is now called `devices-info`;
* displays are now correctly detected and their name listed in the output;
* removed the fake `0x00` I2C address used for mock sensor/display;
* tweaked the MCP2221 message to be only visible when detected;

Fixes #331.