### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
 
     steps:
     - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Live backend for SAM at Biosphere 2"
 readme = "README.md"
 #license = { file="LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     #"License :: OSI Approved :: MIT License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ aiomqtt==2.5.1
 paho-mqtt==2.1.0
 netifaces==0.11.0
 jinja2==3.1.6
-tomli==2.4.1
 flask==3.1.3
 gunicorn==26.0.0
 

--- a/src/simoc_sam/displays/utils.py
+++ b/src/simoc_sam/displays/utils.py
@@ -7,7 +7,7 @@ import asyncio
 from collections import defaultdict
 from dataclasses import dataclass
 
-import tomli
+import tomllib
 import aiomqtt
 
 from PIL import Image, ImageDraw, ImageFont
@@ -33,7 +33,7 @@ DISPLAYS_TOML = pathlib.Path(__file__).with_name('displays.toml')
 def load_display_data(file_path=DISPLAYS_TOML):
     """Load display configuration from displays.toml."""
     with open(file_path, 'rb') as f:
-        displays = tomli.load(f)
+        displays = tomllib.load(f)
     display_data = {}
     for display_key, display_info in displays.items():
         display_data[display_key] = DisplayData(

--- a/src/simoc_sam/sensors/utils.py
+++ b/src/simoc_sam/sensors/utils.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from .basesensor import MQTTWrapper
 from .. import config
 
-import tomli
+import tomllib
 
 
 def format_reading(reading, *, time_fmt='%H:%M:%S', sensor_info=None):
@@ -69,7 +69,7 @@ SENSORS_TOML = pathlib.Path(__file__).with_name('sensors.toml')
 
 def load_sensor_data(file_path=SENSORS_TOML):
     with open(file_path, 'rb') as f:
-        sensors = tomli.load(f)
+        sensors = tomllib.load(f)
     sensor_data = {}
     for sensor_name, sensor_info in sensors.items():
         sensor_data[sensor_name] = SensorData(


### PR DESCRIPTION
This PR updates the supported versions to >=3.11.
Raspberry OS Bookworm still has 3.11, Trixie has 3.13, so both are still supported.
Since `tomllib` has been added in 3.11, we no longer need `tomli` in the dependencies.